### PR TITLE
Add features from slimevr modified lib

### DIFF
--- a/src/LSM6DSV16XSensor.cpp
+++ b/src/LSM6DSV16XSensor.cpp
@@ -243,7 +243,8 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_X_Sensitivity(float *Sensitivity)
  * @param  full_scale enum with type lsm6dsv16x_xl_full_scale_t to be converted
  * @retval sensitivity as float
  */
-float LSM6DSV16XSensor::Convert_X_Sensitivity(lsm6dsv16x_xl_full_scale_t full_scale) {
+float LSM6DSV16XSensor::Convert_X_Sensitivity(lsm6dsv16x_xl_full_scale_t full_scale)
+{
   float Sensitivity = 0.0f;
   /* Store the Sensitivity based on actual full scale. */
   switch (full_scale) {
@@ -825,9 +826,9 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_X_User_Offset(float x, float y, fl
   int8_t xyz[3];
 
   if ( // about +- 2 G's for high and +- 0.124 G's for low
-      (x <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && x >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX) &&
-      (y <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && y >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX) &&
-      (z <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && z >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX)) { // Then we are under the low requirements
+    (x <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && x >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX) &&
+    (y <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && y >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX) &&
+    (z <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && z >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX)) { // Then we are under the low requirements
     xyz[0] = (int8_t)(x / LSM6DSV16X_ACC_USR_OFF_W_LOW_LSB);
     xyz[1] = (int8_t)(y / LSM6DSV16X_ACC_USR_OFF_W_LOW_LSB);
     xyz[2] = (int8_t)(z / LSM6DSV16X_ACC_USR_OFF_W_LOW_LSB);
@@ -835,15 +836,14 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_X_User_Offset(float x, float y, fl
   }
 
   else if ( // about +- 2 G's for high and +- 0.124 G's for low
-      (x <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && x >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX) &&
-      (y <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && y >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX) &&
-      (z <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && z >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX)) { // Then we are under the high requirements
+    (x <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && x >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX) &&
+    (y <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && y >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX) &&
+    (z <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && z >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX)) { // Then we are under the high requirements
     xyz[0] = (int8_t)(x / LSM6DSV16X_ACC_USR_OFF_W_HIGH_LSB);
     xyz[1] = (int8_t)(y / LSM6DSV16X_ACC_USR_OFF_W_HIGH_LSB);
     xyz[2] = (int8_t)(z / LSM6DSV16X_ACC_USR_OFF_W_HIGH_LSB);
     ctrl9.usr_off_w = true; //(0: 2^-10 g/LSB; 1: 2^-6 g/LSB)
-  }
-  else {
+  } else {
     return LSM6DSV16X_ERROR; // Value too big
   }
 
@@ -2555,7 +2555,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Set_Mode(uint8_t Mode)
       newMode = LSM6DSV16X_BYPASS_TO_FIFO_MODE;
       break;
     default:
-    return LSM6DSV16X_ERROR;
+      return LSM6DSV16X_ERROR;
   }
   fifo_mode = newMode;
   if (lsm6dsv16x_fifo_mode_set(&reg_ctx, fifo_mode) != LSM6DSV16X_OK) {
@@ -2795,7 +2795,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Disable_Timestamp()
 }
 
 /**
- * @brief  Set the decimation of timestamp for how often FIFO will be updated with timestamp value 
+ * @brief  Set the decimation of timestamp for how often FIFO will be updated with timestamp value
  * @param  decimation FIFO Timestamp Decimation
  * @retval 0 in case of success, an error code otherwise
  */
@@ -3288,20 +3288,20 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_Temp_ODR(float *Odr)
   }
 
   switch (ctrl4.odr_t_batch) {
-  case LSM6DSV16X_TEMP_NOT_BATCHED:
-    *Odr = 0;
-    break;
-  case LSM6DSV16X_TEMP_BATCHED_AT_1Hz875:
-    *Odr = 1.875f;
-    break;
-  case LSM6DSV16X_TEMP_BATCHED_AT_15Hz:
-    *Odr = 15;
-    break;
-  case LSM6DSV16X_TEMP_BATCHED_AT_60Hz:
-    *Odr = 60;
-    break;
-  default:
-    break;
+    case LSM6DSV16X_TEMP_NOT_BATCHED:
+      *Odr = 0;
+      break;
+    case LSM6DSV16X_TEMP_BATCHED_AT_1Hz875:
+      *Odr = 1.875f;
+      break;
+    case LSM6DSV16X_TEMP_BATCHED_AT_15Hz:
+      *Odr = 15;
+      break;
+    case LSM6DSV16X_TEMP_BATCHED_AT_60Hz:
+      *Odr = 60;
+      break;
+    default:
+      break;
   }
 
   return LSM6DSV16X_OK;
@@ -3322,22 +3322,19 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_Temp_ODR(float Odr)
 
   if (Odr == 0.0F) {
     ctrl4.odr_t_batch = LSM6DSV16X_TEMP_NOT_BATCHED;
-  }
-  else if (Odr <= 1.875F) {
+  } else if (Odr <= 1.875F) {
     ctrl4.odr_t_batch = LSM6DSV16X_TEMP_BATCHED_AT_1Hz875;
-  }
-  else if (Odr <= 15.0F) {
+  } else if (Odr <= 15.0F) {
     ctrl4.odr_t_batch = LSM6DSV16X_TEMP_BATCHED_AT_15Hz;
-  }
-  else {
+  } else {
     ctrl4.odr_t_batch = LSM6DSV16X_TEMP_BATCHED_AT_60Hz;
   }
 
   return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_write_reg(
-      &reg_ctx,
-      LSM6DSV16X_FIFO_CTRL4,
-      (uint8_t *)&ctrl4,
-      1);
+           &reg_ctx,
+           LSM6DSV16X_FIFO_CTRL4,
+           (uint8_t *)&ctrl4,
+           1);
 }
 
 /**
@@ -3408,7 +3405,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Test_X_IMU(uint8_t TestType)
   if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, LSM6DSV16X_4g) != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
-  delay(100); // Wait for Accelerometer to stabalize;
+  delay(100); // Wait for Accelerometer to stabilize;
   memset(val_st_off, 0x00, 3 * sizeof(float));
   memset(val_st_on, 0x00, 3 * sizeof(float));
 
@@ -3465,8 +3462,9 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Test_X_IMU(uint8_t TestType)
   }
 
   for (uint8_t i = 0; i < 3; i++) {
-    if ((LSM6DSV16X_MIN_ST_LIMIT_mg > test_val[i]) || (test_val[i] > LSM6DSV16X_MAX_ST_LIMIT_mg))
+    if ((LSM6DSV16X_MIN_ST_LIMIT_mg > test_val[i]) || (test_val[i] > LSM6DSV16X_MAX_ST_LIMIT_mg)) {
       return LSM6DSV16X_ERROR;
+    }
   }
 
   if (lsm6dsv16x_xl_self_test_set(&reg_ctx, LSM6DSV16X_XL_ST_DISABLE) != LSM6DSV16X_OK) {
@@ -3480,7 +3478,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Test_X_IMU(uint8_t TestType)
 }
 
 /**
- * @brief  Get the LSM6DSV accelerometer sensor raw axes when avaiable (Blocking)
+ * @brief  Get the LSM6DSV accelerometer sensor raw axes when available (Blocking)
  * @param  Value pointer where the raw values of the axes are written
  * @retval 0 in case of success, an error code otherwise
  */
@@ -3993,8 +3991,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_SFLP_Batch(bool GameRotation, bool
     if (lsm6dsv16x_sflp_game_rotation_set(&reg_ctx, PROPERTY_DISABLE)) {
       return LSM6DSV16X_ERROR;
     }
-  }
-  else {
+  } else {
     /* Enable SFLP low power */
     if (lsm6dsv16x_sflp_game_rotation_set(&reg_ctx, PROPERTY_ENABLE)) {
       return LSM6DSV16X_ERROR;
@@ -4016,7 +4013,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_SFLP_ODR(float odr)
                                      : odr <= 60  ? LSM6DSV16X_SFLP_60Hz
                                      : odr <= 120 ? LSM6DSV16X_SFLP_120Hz
                                      : odr <= 240 ? LSM6DSV16X_SFLP_240Hz
-                                                  : LSM6DSV16X_SFLP_480Hz;
+                                     : LSM6DSV16X_SFLP_480Hz;
 
   return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_sflp_data_rate_set(&reg_ctx, rate);
 }
@@ -4074,7 +4071,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Reset_SFLP(void)
  */
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Block_Data_Update()
 {
-    return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_ENABLE);
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_ENABLE);
 }
 
 /**
@@ -4083,7 +4080,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Block_Data_Update()
  */
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_Block_Data_Update()
 {
-    return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_DISABLE);
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_DISABLE);
 }
 
 /**
@@ -4105,7 +4102,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_Auto_Increment()
 }
 
 /**
- * @brief Preform a full reset of the LSM6DSV16X
+ * @brief Perform a full reset of the LSM6DSV16X
  * @param  flags lsm6dsv16x_reset_t flags for what to reset
  * @retval 0 in case of success, an error code otherwise
  */
@@ -4164,8 +4161,9 @@ int32_t LSM6DSV16X_io_read(void *handle, uint8_t ReadAddr, uint8_t *pBuffer, uin
   return ((LSM6DSV16XSensor *)handle)->IO_Read(pBuffer, ReadAddr, nBytesToRead);
 }
 
-void LSM6DSV_sleep(uint32_t ms) {
-    delay(ms);
+void LSM6DSV_sleep(uint32_t ms)
+{
+  delay(ms);
 }
 
 /**

--- a/src/LSM6DSV16XSensor.cpp
+++ b/src/LSM6DSV16XSensor.cpp
@@ -44,12 +44,13 @@
 /* Class Implementation ------------------------------------------------------*/
 /** Constructor
  * @param i2c object of an helper class which handles the I2C peripheral
- * @param address the address of the component"s instance
+ * @param address the address of the component's instance
  */
 LSM6DSV16XSensor::LSM6DSV16XSensor(TwoWire *i2c, uint8_t address) : dev_i2c(i2c), address(address)
 {
   reg_ctx.write_reg = LSM6DSV16X_io_write;
   reg_ctx.read_reg = LSM6DSV16X_io_read;
+  reg_ctx.mdelay = LSM6DSV16X_sleep;
   reg_ctx.handle = (void *)this;
   dev_spi = NULL;
   acc_is_enabled = 0L;
@@ -65,6 +66,7 @@ LSM6DSV16XSensor::LSM6DSV16XSensor(SPIClass *spi, int cs_pin, uint32_t spi_speed
 {
   reg_ctx.write_reg = LSM6DSV16X_io_write;
   reg_ctx.read_reg = LSM6DSV16X_io_read;
+  reg_ctx.mdelay = LSM6DSV16X_sleep;
   reg_ctx.handle = (void *)this;
   dev_i2c = NULL;
   acc_is_enabled = 0L;
@@ -90,7 +92,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::begin()
   }
 
   /* Enable BDU */
-  if (lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_ENABLE) != LSM6DSV16X_OK) {
+  if (Enable_Block_Data_Update() != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
 
@@ -222,7 +224,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_X()
  */
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_X_Sensitivity(float *Sensitivity)
 {
-  LSM6DSV16XStatusTypeDef ret = LSM6DSV16X_OK;
   lsm6dsv16x_xl_full_scale_t full_scale;
 
   /* Read actual full scale selection from sensor. */
@@ -230,30 +231,39 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_X_Sensitivity(float *Sensitivity)
     return LSM6DSV16X_ERROR;
   }
 
+  *Sensitivity = Convert_X_Sensitivity(full_scale);
+  if (*Sensitivity == 0.0f) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Get the LSM6DSV16X accelerometer sensor from type lsm6dsv16x_xl_full_scale_t
+ * @param  full_scale enum with type lsm6dsv16x_xl_full_scale_t to be converted
+ * @retval sensitivity as float
+ */
+float LSM6DSV16XSensor::Convert_X_Sensitivity(lsm6dsv16x_xl_full_scale_t full_scale) {
+  float Sensitivity = 0.0f;
   /* Store the Sensitivity based on actual full scale. */
   switch (full_scale) {
     case LSM6DSV16X_2g:
-      *Sensitivity = LSM6DSV16X_ACC_SENSITIVITY_FS_2G;
+      Sensitivity = LSM6DSV16X_ACC_SENSITIVITY_FS_2G;
       break;
 
     case LSM6DSV16X_4g:
-      *Sensitivity = LSM6DSV16X_ACC_SENSITIVITY_FS_4G;
+      Sensitivity = LSM6DSV16X_ACC_SENSITIVITY_FS_4G;
       break;
 
     case LSM6DSV16X_8g:
-      *Sensitivity = LSM6DSV16X_ACC_SENSITIVITY_FS_8G;
+      Sensitivity = LSM6DSV16X_ACC_SENSITIVITY_FS_8G;
       break;
 
     case LSM6DSV16X_16g:
-      *Sensitivity = LSM6DSV16X_ACC_SENSITIVITY_FS_16G;
-      break;
-
-    default:
-      ret = LSM6DSV16X_ERROR;
+      Sensitivity = LSM6DSV16X_ACC_SENSITIVITY_FS_16G;
       break;
   }
-
-  return ret;
+  return Sensitivity;
 }
 
 /**
@@ -340,7 +350,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_X_ODR(float *Odr)
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_X_Axes(int32_t *Acceleration)
 {
   lsm6dsv16x_axis3bit16_t data_raw;
-  float sensitivity = 0.0f;
+  float sensitivity = Convert_X_Sensitivity(acc_fs);
 
   /* Read raw data values. */
   if (lsm6dsv16x_acceleration_raw_get(&reg_ctx, data_raw.i16bit) != LSM6DSV16X_OK) {
@@ -348,7 +358,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_X_Axes(int32_t *Acceleration)
   }
 
   /* Get LSM6DSV16X actual sensitivity. */
-  if (Get_X_Sensitivity(&sensitivity) != LSM6DSV16X_OK) {
+  if (sensitivity == 0.0f) {
     return LSM6DSV16X_ERROR;
   }
 
@@ -557,7 +567,12 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_X_FS(int32_t FullScale)
            : (FullScale <= 8) ? LSM6DSV16X_8g
            :                    LSM6DSV16X_16g;
 
-  if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, new_fs) != LSM6DSV16X_OK) {
+  if (new_fs == acc_fs) {
+    return LSM6DSV16X_OK;
+  }
+  acc_fs = new_fs;
+
+  if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, acc_fs) != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
 
@@ -753,6 +768,92 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_X_Filter_Mode(uint8_t LowHighPassF
     if (lsm6dsv16x_filt_xl_lp2_bandwidth_set(&reg_ctx, (lsm6dsv16x_filt_xl_lp2_bandwidth_t)FilterMode) != LSM6DSV16X_OK) {
       return LSM6DSV16X_ERROR;
     }
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Enable acceleration offset
+ * @param  enable the acceleration offset
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_X_User_Offset()
+{
+  lsm6dsv16x_ctrl9_t ctrl9;
+  if (lsm6dsv16x_read_reg(&reg_ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  ctrl9.usr_off_on_out = PROPERTY_ENABLE;
+
+  if (lsm6dsv16x_write_reg(&reg_ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Disable acceleration offset
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_X_User_Offset()
+{
+  lsm6dsv16x_ctrl9_t ctrl9;
+  if (lsm6dsv16x_read_reg(&reg_ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  ctrl9.usr_off_on_out = PROPERTY_DISABLE;
+
+  if (lsm6dsv16x_write_reg(&reg_ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Set the offset values for the acceleration
+ * @param  x the acceleration offset in the x axis to be set
+ * @param  y the acceleration offset in the y axis to be set
+ * @param  z the acceleration offset in the z axis to be set
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_X_User_Offset(float x, float y, float z)
+{
+  lsm6dsv16x_ctrl9_t ctrl9;
+  if (lsm6dsv16x_read_reg(&reg_ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  int8_t xyz[3];
+
+  if ( // about +- 2 G's for high and +- 0.124 G's for low
+      (x <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && x >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX) &&
+      (y <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && y >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX) &&
+      (z <= LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX && z >= -LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX)) { // Then we are under the low requirements
+    xyz[0] = (int8_t)(x / LSM6DSV16X_ACC_USR_OFF_W_LOW_LSB);
+    xyz[1] = (int8_t)(y / LSM6DSV16X_ACC_USR_OFF_W_LOW_LSB);
+    xyz[2] = (int8_t)(z / LSM6DSV16X_ACC_USR_OFF_W_LOW_LSB);
+    ctrl9.usr_off_w = false; //(0: 2^-10 g/LSB; 1: 2^-6 g/LSB)
+  }
+
+  else if ( // about +- 2 G's for high and +- 0.124 G's for low
+      (x <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && x >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX) &&
+      (y <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && y >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX) &&
+      (z <= LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX && z >= -LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX)) { // Then we are under the high requirements
+    xyz[0] = (int8_t)(x / LSM6DSV16X_ACC_USR_OFF_W_HIGH_LSB);
+    xyz[1] = (int8_t)(y / LSM6DSV16X_ACC_USR_OFF_W_HIGH_LSB);
+    xyz[2] = (int8_t)(z / LSM6DSV16X_ACC_USR_OFF_W_HIGH_LSB);
+    ctrl9.usr_off_w = true; //(0: 2^-10 g/LSB; 1: 2^-6 g/LSB)
+  }
+  else {
+    return LSM6DSV16X_ERROR; // Value too big
+  }
+
+  if (lsm6dsv16x_write_reg(&reg_ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  // convert from float in G's to what it wants. Signed byte
+  if (lsm6dsv16x_write_reg(&reg_ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&xyz, 3) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
   }
   return LSM6DSV16X_OK;
 }
@@ -2305,6 +2406,22 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_Tilt_Detection()
 }
 
 /**
+ * @brief  Resets the fifo to an empty state
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Reset()
+{
+  if (lsm6dsv16x_fifo_mode_set(&reg_ctx, LSM6DSV16X_BYPASS_MODE) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (lsm6dsv16x_fifo_mode_set(&reg_ctx, fifo_mode) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
   * @brief  Get the LSM6DSV16X FIFO number of samples
 
   * @param  NumSamples number of samples
@@ -2416,7 +2533,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Set_Stop_On_Fth(uint8_t Status)
   */
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Set_Mode(uint8_t Mode)
 {
-  LSM6DSV16XStatusTypeDef ret = LSM6DSV16X_OK;
   lsm6dsv16x_fifo_mode_t newMode = LSM6DSV16X_BYPASS_MODE;
 
   switch (Mode) {
@@ -2439,19 +2555,14 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Set_Mode(uint8_t Mode)
       newMode = LSM6DSV16X_BYPASS_TO_FIFO_MODE;
       break;
     default:
-      ret = LSM6DSV16X_ERROR;
-      break;
+    return LSM6DSV16X_ERROR;
   }
-
-  if (ret == LSM6DSV16X_ERROR) {
+  fifo_mode = newMode;
+  if (lsm6dsv16x_fifo_mode_set(&reg_ctx, fifo_mode) != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
 
-  if (lsm6dsv16x_fifo_mode_set(&reg_ctx, newMode) != LSM6DSV16X_OK) {
-    return LSM6DSV16X_ERROR;
-  }
-
-  return ret;
+  return LSM6DSV16X_OK;
 }
 
 /**
@@ -2492,14 +2603,14 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Data(uint8_t *Data)
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_X_Axes(int32_t *Acceleration)
 {
   lsm6dsv16x_axis3bit16_t data_raw;
-  float sensitivity = 0.0f;
+  float sensitivity = Convert_X_Sensitivity(acc_fs);
   float acceleration_float[3];
 
   if (FIFO_Get_Data(data_raw.u8bit) != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
 
-  if (Get_X_Sensitivity(&sensitivity) != LSM6DSV16X_OK) {
+  if (sensitivity == 0.0f) {
     return LSM6DSV16X_ERROR;
   }
   acceleration_float[0] = (float)data_raw.i16bit[0] * sensitivity;
@@ -2550,14 +2661,14 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Set_X_BDR(float Bdr)
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_G_Axes(int32_t *AngularVelocity)
 {
   lsm6dsv16x_axis3bit16_t data_raw;
-  float sensitivity = 0.0f;
+  float sensitivity = Convert_G_Sensitivity(gyro_fs);
   float angular_velocity_float[3];
 
   if (FIFO_Get_Data(data_raw.u8bit) != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
 
-  if (Get_G_Sensitivity(&sensitivity) != LSM6DSV16X_OK) {
+  if (sensitivity == 0.0f) {
     return LSM6DSV16X_ERROR;
   }
 
@@ -2574,7 +2685,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_G_Axes(int32_t *AngularVeloci
 
 /**
   * @brief  Set the LSM6DSV16X FIFO gyro BDR value
-
   * @param  Bdr FIFO gyro BDR value
   * @retval 0 in case of success, an error code otherwise
   */
@@ -2597,6 +2707,116 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Set_G_BDR(float Bdr)
             :                    LSM6DSV16X_GY_BATCHED_AT_7680Hz;
 
   return (LSM6DSV16XStatusTypeDef) lsm6dsv16x_fifo_gy_batch_set(&reg_ctx, new_bdr);
+}
+
+/**
+ * @brief  Get the LSM6DSV16X FIFO status
+ * @param  Status pointer for FIFO status
+ * @retval 0 in case of success, an error code otherwise
+*/
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Status(lsm6dsv16x_fifo_status_t *Status)
+{
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_fifo_status_get(&reg_ctx, Status);
+}
+
+/**
+  * @brief  Get the Rotation Vector values
+  * @param  rvec pointer where the Rotation Vector values are written
+  * @retval 0 in case of success, an error code otherwise
+  */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Rotation_Vector(float *rvec)
+{
+  lsm6dsv16x_axis3bit16_t data_raw;
+
+  if (FIFO_Get_Data(data_raw.u8bit) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  sflp2q(rvec, (uint16_t *)&data_raw.i16bit[0]);
+
+  return LSM6DSV16X_OK;
+}
+
+/**
+  * @brief  Get the Gravity Vector values
+  * @param  gvec pointer where the Gravity Vector values are written
+  * @retval 0 in case of success, an error code otherwise
+  */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Gravity_Vector(float *gvec)
+{
+  lsm6dsv16x_axis3bit16_t data_raw;
+
+  if (FIFO_Get_Data(data_raw.u8bit) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  gvec[0] = lsm6dsv16x_from_sflp_to_mg(data_raw.i16bit[0]);
+  gvec[1] = lsm6dsv16x_from_sflp_to_mg(data_raw.i16bit[1]);
+  gvec[2] = lsm6dsv16x_from_sflp_to_mg(data_raw.i16bit[2]);
+
+  return LSM6DSV16X_OK;
+}
+
+/**
+  * @brief  Get the Gravity Bias values
+  * @param  gbias pointer where the Gravity Bias values are written
+  * @retval 0 in case of success, an error code otherwise
+  */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Gyroscope_Bias(float *gbias)
+{
+  lsm6dsv16x_axis3bit16_t data_raw;
+
+  if (FIFO_Get_Data(data_raw.u8bit) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  gbias[0] = lsm6dsv16x_from_fs125_to_mdps(data_raw.i16bit[0]);
+  gbias[1] = lsm6dsv16x_from_fs125_to_mdps(data_raw.i16bit[1]);
+  gbias[2] = lsm6dsv16x_from_fs125_to_mdps(data_raw.i16bit[2]);
+
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief Enable the LSM6DSV16X FIFO Timestamp
+ * @retval 0 in case of success, an error code otherwise
+*/
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Enable_Timestamp()
+{
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_timestamp_set(&reg_ctx, PROPERTY_ENABLE);
+}
+
+/**
+ * @brief Disable the LSM6DSV16X FIFO Timestamp
+ * @retval 0 in case of success, an error code otherwise
+*/
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Disable_Timestamp()
+{
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_timestamp_set(&reg_ctx, PROPERTY_DISABLE);
+}
+
+/**
+ * @brief  Set the decimation of timestamp for how often FIFO will be updated with timestamp value 
+ * @param  decimation FIFO Timestamp Decimation
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Set_Timestamp_Decimation(uint8_t decimation)
+{
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_fifo_timestamp_batch_set(&reg_ctx, (lsm6dsv16x_fifo_timestamp_batch_t)decimation);
+}
+
+/**
+ * @brief  Get the LSM6DSV16X FIFO Timestamp
+ * @param  timestamp FIFO Timestamp
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Timestamp(uint32_t *timestamp)
+{
+  uint32_t raw_data[2]; //first is timestamp second is half full of meta data
+  if (FIFO_Get_Data((uint8_t *)raw_data) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  *timestamp = raw_data[0];
+  return LSM6DSV16X_OK;
 }
 
 /**
@@ -2653,7 +2873,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_G()
  */
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_G_Sensitivity(float *Sensitivity)
 {
-  LSM6DSV16XStatusTypeDef ret = LSM6DSV16X_OK;
   lsm6dsv16x_gy_full_scale_t full_scale;
 
   /* Read actual full scale selection from sensor. */
@@ -2661,38 +2880,43 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_G_Sensitivity(float *Sensitivity)
     return LSM6DSV16X_ERROR;
   }
 
+  *Sensitivity = Convert_G_Sensitivity(full_scale);
+  if (*Sensitivity == 0.0f) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+float LSM6DSV16XSensor::Convert_G_Sensitivity(lsm6dsv16x_gy_full_scale_t full_scale)
+{
+  float Sensitivity = 0.0f;
   /* Store the sensitivity based on actual full scale. */
   switch (full_scale) {
     case LSM6DSV16X_125dps:
-      *Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_125DPS;
+      Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_125DPS;
       break;
 
     case LSM6DSV16X_250dps:
-      *Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_250DPS;
+      Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_250DPS;
       break;
 
     case LSM6DSV16X_500dps:
-      *Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_500DPS;
+      Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_500DPS;
       break;
 
     case LSM6DSV16X_1000dps:
-      *Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_1000DPS;
+      Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_1000DPS;
       break;
 
     case LSM6DSV16X_2000dps:
-      *Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_2000DPS;
+      Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_2000DPS;
       break;
 
     case LSM6DSV16X_4000dps:
-      *Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_4000DPS;
-      break;
-
-    default:
-      ret = LSM6DSV16X_ERROR;
+      Sensitivity = LSM6DSV16X_GYRO_SENSITIVITY_FS_4000DPS;
       break;
   }
-
-  return ret;
+  return Sensitivity;
 }
 
 /**
@@ -2843,12 +3067,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_G_ODR_When_Enabled(float Odr)
             : (Odr <= 3840.0f) ? LSM6DSV16X_ODR_AT_3840Hz
             :                    LSM6DSV16X_ODR_AT_7680Hz;
 
-  /* Output data rate selection. */
-  if (lsm6dsv16x_gy_data_rate_set(&reg_ctx, new_odr) != LSM6DSV16X_OK) {
-    return LSM6DSV16X_ERROR;
-  }
-
-  return LSM6DSV16X_OK;
+  return (LSM6DSV16XStatusTypeDef) lsm6dsv16x_gy_data_rate_set(&reg_ctx, new_odr);
 }
 
 /**
@@ -2937,11 +3156,12 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_G_FS(int32_t FullScale)
            : (FullScale <= 2000) ? LSM6DSV16X_2000dps
            :                       LSM6DSV16X_4000dps;
 
-  if (lsm6dsv16x_gy_full_scale_set(&reg_ctx, new_fs) != LSM6DSV16X_OK) {
-    return LSM6DSV16X_ERROR;
+  if (new_fs == gyro_fs) {
+    return LSM6DSV16X_OK;
   }
+  gyro_fs = new_fs;
 
-  return LSM6DSV16X_OK;
+  return (LSM6DSV16XStatusTypeDef) lsm6dsv16x_gy_full_scale_set(&reg_ctx, gyro_fs);
 }
 
 /**
@@ -2974,7 +3194,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_G_AxesRaw(int16_t *Value)
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_G_Axes(int32_t *AngularRate)
 {
   lsm6dsv16x_axis3bit16_t data_raw;
-  float sensitivity;
+  float sensitivity = Convert_G_Sensitivity(gyro_fs);
 
   /* Read raw data values. */
   if (lsm6dsv16x_angular_rate_raw_get(&reg_ctx, data_raw.i16bit) != LSM6DSV16X_OK) {
@@ -2982,7 +3202,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_G_Axes(int32_t *AngularRate)
   }
 
   /* Get LSM6DSV16X actual sensitivity. */
-  if (Get_G_Sensitivity(&sensitivity) != LSM6DSV16X_OK) {
+  if (sensitivity == 0.0f) {
     return LSM6DSV16X_ERROR;
   }
 
@@ -3021,7 +3241,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_G_Power_Mode(uint8_t PowerMode)
   if (lsm6dsv16x_gy_mode_set(&reg_ctx, (lsm6dsv16x_gy_mode_t)PowerMode) != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
-
   return LSM6DSV16X_OK;
 }
 
@@ -3055,6 +3274,354 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_G_Filter_Mode(uint8_t LowHighPassF
   return LSM6DSV16X_OK;
 }
 
+/**
+ * @brief  Get the LSM6DSV16X temperature sensor output data rate
+ * @param  Odr pointer where the output data rate is written
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_Temp_ODR(float *Odr)
+{
+  lsm6dsv16x_fifo_ctrl4_t ctrl4;
+
+  if (lsm6dsv16x_read_reg(&reg_ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&ctrl4, 1) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  switch (ctrl4.odr_t_batch) {
+  case LSM6DSV16X_TEMP_NOT_BATCHED:
+    *Odr = 0;
+    break;
+  case LSM6DSV16X_TEMP_BATCHED_AT_1Hz875:
+    *Odr = 1.875f;
+    break;
+  case LSM6DSV16X_TEMP_BATCHED_AT_15Hz:
+    *Odr = 15;
+    break;
+  case LSM6DSV16X_TEMP_BATCHED_AT_60Hz:
+    *Odr = 60;
+    break;
+  default:
+    break;
+  }
+
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Set the LSM6DSV16X temperature sensor output data rate
+ * @param  Odr the output data rate value to be set
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_Temp_ODR(float Odr)
+{
+  lsm6dsv16x_fifo_ctrl4_t ctrl4;
+
+  if (lsm6dsv16x_read_reg(&reg_ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&ctrl4, 1) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (Odr == 0.0F) {
+    ctrl4.odr_t_batch = LSM6DSV16X_TEMP_NOT_BATCHED;
+  }
+  else if (Odr <= 1.875F) {
+    ctrl4.odr_t_batch = LSM6DSV16X_TEMP_BATCHED_AT_1Hz875;
+  }
+  else if (Odr <= 15.0F) {
+    ctrl4.odr_t_batch = LSM6DSV16X_TEMP_BATCHED_AT_15Hz;
+  }
+  else {
+    ctrl4.odr_t_batch = LSM6DSV16X_TEMP_BATCHED_AT_60Hz;
+  }
+
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_write_reg(
+      &reg_ctx,
+      LSM6DSV16X_FIFO_CTRL4,
+      (uint8_t *)&ctrl4,
+      1);
+}
+
+/**
+ * @brief  Returns the raw temperature value from the imu
+ * @param  value pointer where the temperature value is written
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_Temp_Raw(int16_t *value)
+{
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_temperature_raw_get(&reg_ctx, value);
+}
+
+/**
+ * @brief  Runs the ST specified accelerometer and gyroscope self test
+ * @param XTestType LSM6DSV16X_XL_ST_DISABLE  = 0x0, LSM6DSV16X_XL_ST_POSITIVE = 0x1, LSM6DSV16X_XL_ST_NEGATIVE = 0x2
+ * @param GTestType LSM6DSV16X_GY_ST_DISABLE  = 0x0, LSM6DSV16X_GY_ST_POSITIVE = 0x1, LSM6DSV16X_GY_ST_NEGATIVE = 0x2
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Test_IMU(uint8_t XTestType, uint8_t GTestType)
+{
+  uint8_t whoamI;
+
+  if (ReadID(&whoamI) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (whoamI != LSM6DSV16X_ID) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (Test_X_IMU(XTestType) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (Test_G_IMU(GTestType) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Runs the ST specified accelerometer self test
+ * @param TestType LSM6DSV16X_XL_ST_DISABLE  = 0x0, LSM6DSV16X_XL_ST_POSITIVE = 0x1, LSM6DSV16X_XL_ST_NEGATIVE = 0x2
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Test_X_IMU(uint8_t TestType)
+{
+  int16_t data_raw[3];
+  float val_st_off[3];
+  float val_st_on[3];
+  float test_val[3];
+
+  if (Device_Reset(LSM6DSV16X_RESET_CTRL_REGS) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_ENABLE) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  /*
+   * Accelerometer Self Test
+   */
+  if (lsm6dsv16x_xl_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_AT_60Hz) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, LSM6DSV16X_4g) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  delay(100); // Wait for Accelerometer to stabalize;
+  memset(val_st_off, 0x00, 3 * sizeof(float));
+  memset(val_st_on, 0x00, 3 * sizeof(float));
+
+  /*Ignore First Data*/
+  if (Get_X_AxesRaw_When_Aval(data_raw) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  for (uint8_t i = 0; i < 5; i++) {
+    if (Get_X_AxesRaw_When_Aval(data_raw) != LSM6DSV16X_OK) {
+      return LSM6DSV16X_ERROR;
+    }
+
+    /*Average the data in each axis*/
+    for (uint8_t j = 0; j < 3; j++) {
+      val_st_off[j] += lsm6dsv16x_from_fs4_to_mg(data_raw[j]);
+    }
+  }
+
+  /* Calculate the mg average values */
+  for (uint8_t i = 0; i < 3; i++) {
+    val_st_off[i] /= 5.0f;
+  }
+
+  if (lsm6dsv16x_xl_self_test_set(&reg_ctx, (lsm6dsv16x_xl_self_test_t)TestType) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  delay(100);
+
+  /*Ignore First Data*/
+  if (Get_X_AxesRaw_When_Aval(data_raw) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  for (uint8_t i = 0; i < 5; i++) {
+    if (Get_X_AxesRaw_When_Aval(data_raw) != LSM6DSV16X_OK) {
+      return LSM6DSV16X_ERROR;
+    }
+
+    /*Average the data in each axis*/
+    for (uint8_t j = 0; j < 3; j++) {
+      val_st_on[j] += lsm6dsv16x_from_fs4_to_mg(data_raw[j]);
+    }
+  }
+
+  /* Calculate the mg average values */
+  for (uint8_t i = 0; i < 3; i++) {
+    val_st_on[i] /= 5.0f;
+  }
+
+  /* Calculate the mg values for self test */
+  for (uint8_t i = 0; i < 3; i++) {
+    test_val[i] = fabs((val_st_on[i] - val_st_off[i]));
+  }
+
+  for (uint8_t i = 0; i < 3; i++) {
+    if ((LSM6DSV16X_MIN_ST_LIMIT_mg > test_val[i]) || (test_val[i] > LSM6DSV16X_MAX_ST_LIMIT_mg))
+      return LSM6DSV16X_ERROR;
+  }
+
+  if (lsm6dsv16x_xl_self_test_set(&reg_ctx, LSM6DSV16X_XL_ST_DISABLE) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (lsm6dsv16x_xl_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_OFF) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Get the LSM6DSV accelerometer sensor raw axes when avaiable (Blocking)
+ * @param  Value pointer where the raw values of the axes are written
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_X_AxesRaw_When_Aval(int16_t *Value)
+{
+  lsm6dsv16x_data_ready_t drdy;
+  do {
+    if (lsm6dsv16x_flag_data_ready_get(&reg_ctx, &drdy) != LSM6DSV16X_OK) {
+      return LSM6DSV16X_ERROR;
+    }
+  } while (!drdy.drdy_xl);
+
+  if (Get_X_AxesRaw(Value) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Runs the ST specified self test on the acceleration axis of the IMU
+ * @param TestType LSM6DSV16X_GY_ST_DISABLE  = 0x0, LSM6DSV16X_GY_ST_POSITIVE = 0x1, LSM6DSV16X_GY_ST_NEGATIVE = 0x2
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Test_G_IMU(uint8_t TestType = LSM6DSV16X_GY_ST_POSITIVE)
+{
+  int16_t data_raw[3];
+  float test_val[3];
+
+  if (Device_Reset(LSM6DSV16X_RESET_CTRL_REGS) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_ENABLE) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  /*
+   * Gyroscope Self Test
+   */
+
+  if (lsm6dsv16x_gy_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_AT_240Hz) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (lsm6dsv16x_gy_full_scale_set(&reg_ctx, LSM6DSV16X_2000dps) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  delay(100);
+
+  /*Ignore First Data*/
+  if (Get_G_AxesRaw_When_Aval(data_raw) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  float val_st_off[3] = {0};
+  float val_st_on[3] = {0};
+
+  for (uint8_t i = 0; i < 5; i++) {
+    if (Get_G_AxesRaw_When_Aval(data_raw) != LSM6DSV16X_OK) {
+      return LSM6DSV16X_ERROR;
+    }
+
+    /*Average the data in each axis*/
+    for (uint8_t j = 0; j < 3; j++) {
+      val_st_off[j] += lsm6dsv16x_from_fs2000_to_mdps(data_raw[j]);
+    }
+  }
+
+  /* Calculate the mg average values */
+  for (uint8_t i = 0; i < 3; i++) {
+    val_st_off[i] /= 5.0f;
+  }
+
+  if (lsm6dsv16x_gy_self_test_set(&reg_ctx, (lsm6dsv16x_gy_self_test_t)TestType) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  delay(100);
+
+  /*Ignore First Data*/
+  if (Get_G_AxesRaw_When_Aval(data_raw) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  for (uint8_t i = 0; i < 5; i++) {
+    if (Get_G_AxesRaw_When_Aval(data_raw) != LSM6DSV16X_OK) {
+      return LSM6DSV16X_ERROR;
+    }
+
+    /*Average the data in each axis*/
+    for (uint8_t j = 0; j < 3; j++) {
+      val_st_on[j] += lsm6dsv16x_from_fs2000_to_mdps(data_raw[j]);
+    }
+  }
+
+  /* Calculate the mg average values */
+  for (uint8_t i = 0; i < 3; i++) {
+    val_st_on[i] /= 5.0f;
+  }
+
+  /* Calculate the mg values for self test */
+  for (uint8_t i = 0; i < 3; i++) {
+    test_val[i] = fabs((val_st_on[i] - val_st_off[i]));
+  }
+
+  /* Check self test limit */
+  for (uint8_t i = 0; i < 3; i++) {
+    if ((LSM6DSV16X_MIN_ST_LIMIT_mdps > test_val[i]) || (test_val[i] > LSM6DSV16X_MAX_ST_LIMIT_mdps)) {
+      return LSM6DSV16X_ERROR;
+    }
+  }
+
+  if (lsm6dsv16x_gy_self_test_set(&reg_ctx, LSM6DSV16X_GY_ST_DISABLE) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  if (lsm6dsv16x_xl_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_OFF) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Get the LSM6DSV gyroscope sensor raw axes when data available (Blocking)
+ * @param  Value pointer where the raw values of the axes are written
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Get_G_AxesRaw_When_Aval(int16_t *Value)
+{
+  lsm6dsv16x_data_ready_t drdy;
+  do {
+    if (lsm6dsv16x_flag_data_ready_get(&reg_ctx, &drdy) != LSM6DSV16X_OK) {
+      return LSM6DSV16X_ERROR;
+    }
+  } while (!drdy.drdy_gy);
+
+  if (Get_G_AxesRaw(Value) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+  return LSM6DSV16X_OK;
+}
 
 /**
  * @brief  Enable the LSM6DSV16X QVAR feature
@@ -3099,7 +3666,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::QVAR_Disable()
 
   return LSM6DSV16X_OK;
 }
-
 
 /**
  * @brief  Read LSM6DSV16X QVAR output data
@@ -3153,7 +3719,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::QVAR_GetImpedance(uint16_t *val)
   return ret;
 }
 
-
 /**
  * @brief  Set LSM6DSV16X QVAR equivalent input impedance
  * @param  val impedance in MOhm (2400MOhm, 730MOhm, 300MOhm, 255MOhm)
@@ -3193,7 +3758,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::QVAR_SetImpedance(uint16_t val)
  * @param  val pointer where the value is written
  * @retval 0 in case of success, an error code otherwise
  */
-
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::QVAR_GetStatus(uint8_t *val)
 {
   lsm6dsv16x_status_reg_t status;
@@ -3243,14 +3807,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Rotation_Vector()
 {
   lsm6dsv16x_fifo_sflp_raw_t fifo_sflp;
 
-  /* Set full scale */
-  if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, LSM6DSV16X_4g)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_gy_full_scale_set(&reg_ctx, LSM6DSV16X_2000dps)) {
-    return LSM6DSV16X_ERROR;
-  }
-
   if (lsm6dsv16x_fifo_sflp_batch_get(&reg_ctx, &fifo_sflp)) {
     return LSM6DSV16X_ERROR;
   }
@@ -3261,21 +3817,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Rotation_Vector()
     return LSM6DSV16X_ERROR;
   }
 
-  /* Set FIFO mode to Stream mode (aka Continuous Mode) */
-  if (lsm6dsv16x_fifo_mode_set(&reg_ctx, LSM6DSV16X_STREAM_MODE)) {
-    return LSM6DSV16X_ERROR;
-  }
-
-  /* Set Output Data Rate */
-  if (lsm6dsv16x_xl_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_AT_120Hz)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_gy_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_AT_120Hz)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_sflp_data_rate_set(&reg_ctx, LSM6DSV16X_SFLP_120Hz)) {
-    return LSM6DSV16X_ERROR;
-  }
 
   /* Enable SFLP low power */
   if (lsm6dsv16x_sflp_game_rotation_set(&reg_ctx, PROPERTY_ENABLE)) {
@@ -3291,14 +3832,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Rotation_Vector()
 LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_Rotation_Vector()
 {
   lsm6dsv16x_fifo_sflp_raw_t fifo_sflp;
-
-  /* Set full scale */
-  if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, LSM6DSV16X_4g)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_gy_full_scale_set(&reg_ctx, LSM6DSV16X_2000dps)) {
-    return LSM6DSV16X_ERROR;
-  }
 
   if (lsm6dsv16x_fifo_sflp_batch_get(&reg_ctx, &fifo_sflp)) {
     return LSM6DSV16X_ERROR;
@@ -3328,13 +3861,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Gravity_Vector()
 {
   lsm6dsv16x_fifo_sflp_raw_t fifo_sflp;
 
-  /* Set full scale */
-  if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, LSM6DSV16X_4g)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_gy_full_scale_set(&reg_ctx, LSM6DSV16X_2000dps)) {
-    return LSM6DSV16X_ERROR;
-  }
 
   if (lsm6dsv16x_fifo_sflp_batch_get(&reg_ctx, &fifo_sflp)) {
     return LSM6DSV16X_ERROR;
@@ -3346,21 +3872,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Gravity_Vector()
     return LSM6DSV16X_ERROR;
   }
 
-  /* Set FIFO mode to Stream mode (aka Continuous Mode) */
-  if (lsm6dsv16x_fifo_mode_set(&reg_ctx, LSM6DSV16X_STREAM_MODE)) {
-    return LSM6DSV16X_ERROR;
-  }
-
-  /* Set Output Data Rate */
-  if (lsm6dsv16x_xl_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_AT_120Hz)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_gy_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_AT_120Hz)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_sflp_data_rate_set(&reg_ctx, LSM6DSV16X_SFLP_120Hz)) {
-    return LSM6DSV16X_ERROR;
-  }
 
   /* Enable SFLP low power */
   if (lsm6dsv16x_sflp_game_rotation_set(&reg_ctx, PROPERTY_ENABLE)) {
@@ -3413,14 +3924,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Gyroscope_Bias()
 {
   lsm6dsv16x_fifo_sflp_raw_t fifo_sflp;
 
-  /* Set full scale */
-  if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, LSM6DSV16X_4g)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_gy_full_scale_set(&reg_ctx, LSM6DSV16X_2000dps)) {
-    return LSM6DSV16X_ERROR;
-  }
-
   if (lsm6dsv16x_fifo_sflp_batch_get(&reg_ctx, &fifo_sflp)) {
     return LSM6DSV16X_ERROR;
   }
@@ -3428,22 +3931,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Gyroscope_Bias()
   fifo_sflp.gbias = 1;
 
   if (lsm6dsv16x_fifo_sflp_batch_set(&reg_ctx, fifo_sflp)) {
-    return LSM6DSV16X_ERROR;
-  }
-
-  /* Set FIFO mode to Stream mode (aka Continuous Mode) */
-  if (lsm6dsv16x_fifo_mode_set(&reg_ctx, LSM6DSV16X_STREAM_MODE)) {
-    return LSM6DSV16X_ERROR;
-  }
-
-  /* Set Output Data Rate */
-  if (lsm6dsv16x_xl_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_AT_120Hz)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_gy_data_rate_set(&reg_ctx, LSM6DSV16X_ODR_AT_120Hz)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_sflp_data_rate_set(&reg_ctx, LSM6DSV16X_SFLP_120Hz)) {
     return LSM6DSV16X_ERROR;
   }
 
@@ -3462,13 +3949,6 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_Gyroscope_Bias()
 {
   lsm6dsv16x_fifo_sflp_raw_t fifo_sflp;
 
-  /* Set full scale */
-  if (lsm6dsv16x_xl_full_scale_set(&reg_ctx, LSM6DSV16X_4g)) {
-    return LSM6DSV16X_ERROR;
-  }
-  if (lsm6dsv16x_gy_full_scale_set(&reg_ctx, LSM6DSV16X_2000dps)) {
-    return LSM6DSV16X_ERROR;
-  }
 
   if (lsm6dsv16x_fifo_sflp_batch_get(&reg_ctx, &fifo_sflp)) {
     return LSM6DSV16X_ERROR;
@@ -3491,59 +3971,72 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_Gyroscope_Bias()
 }
 
 /**
-  * @brief  Get the Rotation Vector values
-  * @param  rvec pointer where the Rotation Vector values are written
-  * @retval 0 in case of success, an error code otherwise
-  */
-LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Rotation_Vector(float *rvec)
+ * @brief  Bulk set SFLP feature
+ * @param  GameRotation enable/disable Game Rotation Vector SFLP feature
+ * @param  Gravity enable/disable Gravity Vector SFLP feature
+ * @param  gBias enable/disable Gyroscope Bias SFLP feature
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_SFLP_Batch(bool GameRotation, bool Gravity, bool gBias)
 {
-  lsm6dsv16x_axis3bit16_t data_raw;
-
-  if (FIFO_Get_Data(data_raw.u8bit) != LSM6DSV16X_OK) {
+  lsm6dsv16x_fifo_sflp_raw_t fifo_sflp;
+  fifo_sflp.game_rotation = GameRotation;
+  fifo_sflp.gravity = Gravity;
+  fifo_sflp.gbias = gBias;
+  if (lsm6dsv16x_fifo_sflp_batch_set(&reg_ctx, fifo_sflp)) {
     return LSM6DSV16X_ERROR;
   }
-  sflp2q(rvec, (uint16_t *)&data_raw.i16bit[0]);
 
+  /* Check if all SFLP features are disabled */
+  if (!fifo_sflp.game_rotation && !fifo_sflp.gravity && !fifo_sflp.gbias) {
+    /* Disable SFLP */
+    if (lsm6dsv16x_sflp_game_rotation_set(&reg_ctx, PROPERTY_DISABLE)) {
+      return LSM6DSV16X_ERROR;
+    }
+  }
+  else {
+    /* Enable SFLP low power */
+    if (lsm6dsv16x_sflp_game_rotation_set(&reg_ctx, PROPERTY_ENABLE)) {
+      return LSM6DSV16X_ERROR;
+    }
+  }
   return LSM6DSV16X_OK;
 }
 
+
 /**
-  * @brief  Get the Gravity Vector values
-  * @param  gvec pointer where the Gravity Vector values are written
-  * @retval 0 in case of success, an error code otherwise
-  */
-LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Gravity_Vector(float *gvec)
+ * @brief  Set the LSM6DSV16X sensor fusion low power (sflp) output data rate
+ * @param  Odr the output data rate value to be set
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_SFLP_ODR(float odr)
 {
-  lsm6dsv16x_axis3bit16_t data_raw;
+  lsm6dsv16x_sflp_data_rate_t rate = odr <= 15    ? LSM6DSV16X_SFLP_15Hz
+                                     : odr <= 30  ? LSM6DSV16X_SFLP_30Hz
+                                     : odr <= 60  ? LSM6DSV16X_SFLP_60Hz
+                                     : odr <= 120 ? LSM6DSV16X_SFLP_120Hz
+                                     : odr <= 240 ? LSM6DSV16X_SFLP_240Hz
+                                                  : LSM6DSV16X_SFLP_480Hz;
 
-  if (FIFO_Get_Data(data_raw.u8bit) != LSM6DSV16X_OK) {
-    return LSM6DSV16X_ERROR;
-  }
-
-  gvec[0] = lsm6dsv16x_from_sflp_to_mg(data_raw.i16bit[0]);
-  gvec[1] = lsm6dsv16x_from_sflp_to_mg(data_raw.i16bit[1]);
-  gvec[2] = lsm6dsv16x_from_sflp_to_mg(data_raw.i16bit[2]);
-
-  return LSM6DSV16X_OK;
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_sflp_data_rate_set(&reg_ctx, rate);
 }
 
 /**
-  * @brief  Get the Gravity Bias values
-  * @param  gbias pointer where the Gravity Bias values are written
-  * @retval 0 in case of success, an error code otherwise
-  */
-LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::FIFO_Get_Gyroscope_Bias(float *gbias)
+ * @brief  Set the LSM6DSV16X sflp G bias
+ * @param  x the gyro bias in the x axis to be set
+ * @param  y the gyro bias in the y axis to be set
+ * @param  z the gyro bias in the z axis to be set
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Set_SFLP_GBIAS(float x, float y, float z)
 {
-  lsm6dsv16x_axis3bit16_t data_raw;
-
-  if (FIFO_Get_Data(data_raw.u8bit) != LSM6DSV16X_OK) {
+  lsm6dsv16x_sflp_gbias_t val = {0, 0, 0};
+  val.gbias_x = x;
+  val.gbias_y = y;
+  val.gbias_z = z;
+  if (lsm6dsv16x_sflp_game_gbias_set(&reg_ctx, &val) != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
-
-  gbias[0] = lsm6dsv16x_from_fs125_to_mdps(data_raw.i16bit[0]);
-  gbias[1] = lsm6dsv16x_from_fs125_to_mdps(data_raw.i16bit[1]);
-  gbias[2] = lsm6dsv16x_from_fs125_to_mdps(data_raw.i16bit[2]);
-
   return LSM6DSV16X_OK;
 }
 
@@ -3572,6 +4065,62 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Reset_SFLP(void)
   if (lsm6dsv16x_mem_bank_set(&reg_ctx, LSM6DSV16X_MAIN_MEM_BANK) != LSM6DSV16X_OK) {
     return LSM6DSV16X_ERROR;
   }
+  return LSM6DSV16X_OK;
+}
+
+/**
+ * @brief  Enable the LSM6DSV16X block update feature
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Block_Data_Update()
+{
+    return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_ENABLE);
+}
+
+/**
+ * @brief  Disable the LSM6DSV16X block update feature
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_Block_Data_Update()
+{
+    return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_block_data_update_set(&reg_ctx, PROPERTY_DISABLE);
+}
+
+/**
+ * @brief  Enable register address automatically incremented during a multiple byte access with a serial interface.
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Enable_Auto_Increment()
+{
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_auto_increment_set(&reg_ctx, PROPERTY_ENABLE);
+}
+
+/**
+ * @brief  Disable register address automatically incremented during a multiple byte access with a serial interface.
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Disable_Auto_Increment()
+{
+  return (LSM6DSV16XStatusTypeDef)lsm6dsv16x_auto_increment_set(&reg_ctx, PROPERTY_DISABLE);
+}
+
+/**
+ * @brief Preform a full reset of the LSM6DSV16X
+ * @param  flags lsm6dsv16x_reset_t flags for what to reset
+ * @retval 0 in case of success, an error code otherwise
+ */
+LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Device_Reset(LSM6DSV16X_Reset_t flags)
+{
+  if (lsm6dsv16x_reset_set(&reg_ctx, (lsm6dsv16x_reset_t)flags) != LSM6DSV16X_OK) {
+    return LSM6DSV16X_ERROR;
+  }
+
+  lsm6dsv16x_reset_t rst;
+  do {
+    if (lsm6dsv16x_reset_get(&reg_ctx, &rst) != LSM6DSV16X_OK) {
+      return LSM6DSV16X_ERROR;
+    }
+  } while (rst != LSM6DSV16X_READY);
   return LSM6DSV16X_OK;
 }
 
@@ -3605,7 +4154,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Write_Reg(uint8_t Reg, uint8_t Data)
   return LSM6DSV16X_OK;
 }
 
-int32_t LSM6DSV16X_io_write(void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite)
+int32_t LSM6DSV16X_io_write(void *handle, uint8_t WriteAddr, const uint8_t *pBuffer, uint16_t nBytesToWrite)
 {
   return ((LSM6DSV16XSensor *)handle)->IO_Write(pBuffer, WriteAddr, nBytesToWrite);
 }
@@ -3613,6 +4162,10 @@ int32_t LSM6DSV16X_io_write(void *handle, uint8_t WriteAddr, uint8_t *pBuffer, u
 int32_t LSM6DSV16X_io_read(void *handle, uint8_t ReadAddr, uint8_t *pBuffer, uint16_t nBytesToRead)
 {
   return ((LSM6DSV16XSensor *)handle)->IO_Read(pBuffer, ReadAddr, nBytesToRead);
+}
+
+void LSM6DSV_sleep(uint32_t ms) {
+    delay(ms);
 }
 
 /**

--- a/src/LSM6DSV16XSensor.cpp
+++ b/src/LSM6DSV16XSensor.cpp
@@ -3478,7 +3478,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Test_X_IMU(uint8_t TestType)
 }
 
 /**
- * @brief  Get the LSM6DSV accelerometer sensor raw axes when available (Blocking)
+ * @brief  Get the LSM6DSV16X accelerometer sensor raw axes when available (Blocking)
  * @param  Value pointer where the raw values of the axes are written
  * @retval 0 in case of success, an error code otherwise
  */
@@ -3602,7 +3602,7 @@ LSM6DSV16XStatusTypeDef LSM6DSV16XSensor::Test_G_IMU(uint8_t TestType = LSM6DSV1
 }
 
 /**
- * @brief  Get the LSM6DSV gyroscope sensor raw axes when data available (Blocking)
+ * @brief  Get the LSM6DSV16X gyroscope sensor raw axes when data available (Blocking)
  * @param  Value pointer where the raw values of the axes are written
  * @retval 0 in case of success, an error code otherwise
  */
@@ -4161,7 +4161,7 @@ int32_t LSM6DSV16X_io_read(void *handle, uint8_t ReadAddr, uint8_t *pBuffer, uin
   return ((LSM6DSV16XSensor *)handle)->IO_Read(pBuffer, ReadAddr, nBytesToRead);
 }
 
-void LSM6DSV_sleep(uint32_t ms)
+void LSM6DSV16X_sleep(uint32_t ms)
 {
   delay(ms);
 }

--- a/src/LSM6DSV16XSensor.h
+++ b/src/LSM6DSV16XSensor.h
@@ -71,6 +71,16 @@
 
 #define LSM6DSV16X_QVAR_GAIN  78.000f
 
+#define LSM6DSV16X_MIN_ST_LIMIT_mg         50.0f
+#define LSM6DSV16X_MAX_ST_LIMIT_mg       1700.0f
+#define LSM6DSV16X_MIN_ST_LIMIT_mdps   150000.0f
+#define LSM6DSV16X_MAX_ST_LIMIT_mdps   700000.0f
+
+#define LSM6DSV16X_ACC_USR_OFF_W_HIGH_LSB (float)(pow(2, -6))
+#define LSM6DSV16X_ACC_USR_OFF_W_LOW_LSB (float)(pow(2, -10))
+#define LSM6DSV16X_ACC_USR_OFF_W_HIGH_MAX LSM6DSV16X_ACC_USR_OFF_W_HIGH_LSB * INT8_MAX
+#define LSM6DSV16X_ACC_USR_OFF_W_LOW_MAX LSM6DSV16X_ACC_USR_OFF_W_LOW_LSB * INT8_MAX
+
 /* Typedefs ------------------------------------------------------------------*/
 
 typedef enum {
@@ -103,6 +113,12 @@ typedef union {
   int16_t i16bit;
   uint8_t u8bit[2];
 } lsm6dsv16x_axis1bit16_t;
+
+typedef enum {
+  LSM6DSV16X_RESET_GLOBAL = 0x1,
+  LSM6DSV16X_RESET_CAL_PARAM = 0x2,
+  LSM6DSV16X_RESET_CTRL_REGS = 0x4,
+} LSM6DSV16X_Reset_t;
 
 typedef enum {
   LSM6DSV16X_ACC_HIGH_PERFORMANCE_MODE,
@@ -148,6 +164,9 @@ class LSM6DSV16XSensor {
     LSM6DSV16XStatusTypeDef Get_X_Event_Status(LSM6DSV16X_Event_Status_t *Status);
     LSM6DSV16XStatusTypeDef Set_X_Power_Mode(uint8_t PowerMode);
     LSM6DSV16XStatusTypeDef Set_X_Filter_Mode(uint8_t LowHighPassFlag, uint8_t FilterMode);
+    LSM6DSV16XStatusTypeDef Enable_X_User_Offset();
+    LSM6DSV16XStatusTypeDef Disable_X_User_Offset();
+    LSM6DSV16XStatusTypeDef Set_X_User_Offset(float x, float y, float z);
 
     LSM6DSV16XStatusTypeDef Enable_G();
     LSM6DSV16XStatusTypeDef Disable_G();
@@ -161,6 +180,14 @@ class LSM6DSV16XSensor {
     LSM6DSV16XStatusTypeDef Get_G_DRDY_Status(uint8_t *Status);
     LSM6DSV16XStatusTypeDef Set_G_Power_Mode(uint8_t PowerMode);
     LSM6DSV16XStatusTypeDef Set_G_Filter_Mode(uint8_t LowHighPassFlag, uint8_t FilterMode);
+
+    LSM6DSV16XStatusTypeDef Get_Temp_ODR(float *Odr);
+    LSM6DSV16XStatusTypeDef Set_Temp_ODR(float Odr);
+    LSM6DSV16XStatusTypeDef Get_Temp_Raw(int16_t *value);
+
+    LSM6DSV16XStatusTypeDef Test_IMU(uint8_t XTestType, uint8_t GTestType);
+    LSM6DSV16XStatusTypeDef Test_X_IMU(uint8_t TestType);
+    LSM6DSV16XStatusTypeDef Test_G_IMU(uint8_t TestType);
 
     LSM6DSV16XStatusTypeDef Enable_6D_Orientation(LSM6DSV16X_SensorIntPin_t IntPin);
     LSM6DSV16XStatusTypeDef Disable_6D_Orientation();
@@ -212,6 +239,15 @@ class LSM6DSV16XSensor {
     LSM6DSV16XStatusTypeDef FIFO_Set_X_BDR(float Bdr);
     LSM6DSV16XStatusTypeDef FIFO_Get_G_Axes(int32_t *AngularVelocity);
     LSM6DSV16XStatusTypeDef FIFO_Set_G_BDR(float Bdr);
+    LSM6DSV16XStatusTypeDef FIFO_Get_Status(lsm6dsv16x_fifo_status_t *Status);
+    LSM6DSV16XStatusTypeDef FIFO_Get_Rotation_Vector(float *rvec);
+    LSM6DSV16XStatusTypeDef FIFO_Get_Gravity_Vector(float *gvec);
+    LSM6DSV16XStatusTypeDef FIFO_Get_Gyroscope_Bias(float *gbias);
+    LSM6DSV16XStatusTypeDef FIFO_Enable_Timestamp();
+    LSM6DSV16XStatusTypeDef FIFO_Disable_Timestamp();
+    LSM6DSV16XStatusTypeDef FIFO_Set_Timestamp_Decimation(uint8_t decimation);
+    LSM6DSV16XStatusTypeDef FIFO_Get_Timestamp(uint32_t *timestamp);
+    LSM6DSV16XStatusTypeDef FIFO_Reset();
 
     LSM6DSV16XStatusTypeDef QVAR_Enable();
     LSM6DSV16XStatusTypeDef QVAR_Disable();
@@ -229,13 +265,19 @@ class LSM6DSV16XSensor {
     LSM6DSV16XStatusTypeDef Disable_Gravity_Vector();
     LSM6DSV16XStatusTypeDef Enable_Gyroscope_Bias();
     LSM6DSV16XStatusTypeDef Disable_Gyroscope_Bias();
-    LSM6DSV16XStatusTypeDef FIFO_Get_Rotation_Vector(float *rvec);
-    LSM6DSV16XStatusTypeDef FIFO_Get_Gravity_Vector(float *gvec);
-    LSM6DSV16XStatusTypeDef FIFO_Get_Gyroscope_Bias(float *gbias);
+    LSM6DSV16XStatusTypeDef Set_SFLP_Batch(bool GameRotation, bool Gravity, bool gBias);
+    LSM6DSV16XStatusTypeDef Set_SFLP_ODR(float Odr);
+    LSM6DSV16XStatusTypeDef Set_SFLP_GBIAS(float x, float y, float z);
     LSM6DSV16XStatusTypeDef Reset_SFLP();
 
     LSM6DSV16XStatusTypeDef Read_Reg(uint8_t Reg, uint8_t *Data);
     LSM6DSV16XStatusTypeDef Write_Reg(uint8_t Reg, uint8_t Data);
+
+    LSM6DSV16XStatusTypeDef Enable_Block_Data_Update();
+    LSM6DSV16XStatusTypeDef Disable_Block_Data_Update();
+    LSM6DSV16XStatusTypeDef Enable_Auto_Increment();
+    LSM6DSV16XStatusTypeDef Disable_Auto_Increment();
+    LSM6DSV16XStatusTypeDef Device_Reset(LSM6DSV16X_Reset_t flags = LSM6DSV16X_RESET_GLOBAL);
 
     /**
      * @brief Utility function to read data.
@@ -291,7 +333,7 @@ class LSM6DSV16XSensor {
      * @param  NumByteToWrite: number of bytes to write.
      * @retval 0 if ok, an error code otherwise.
      */
-    uint8_t IO_Write(uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t NumByteToWrite)
+    uint8_t IO_Write(const uint8_t *pBuffer, uint8_t RegisterAddr, uint16_t NumByteToWrite)
     {
       if (dev_spi) {
         dev_spi->beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
@@ -333,9 +375,14 @@ class LSM6DSV16XSensor {
     LSM6DSV16XStatusTypeDef Set_X_ODR_When_Disabled(float Odr);
     LSM6DSV16XStatusTypeDef Set_G_ODR_When_Enabled(float Odr);
     LSM6DSV16XStatusTypeDef Set_G_ODR_When_Disabled(float Odr);
+    LSM6DSV16XStatusTypeDef Get_X_AxesRaw_When_Aval(int16_t *Value);
+    LSM6DSV16XStatusTypeDef Get_G_AxesRaw_When_Aval(int16_t *Value);
     LSM6DSV16XStatusTypeDef npy_halfbits_to_floatbits(uint16_t h, uint32_t *f);
     LSM6DSV16XStatusTypeDef npy_half_to_float(uint16_t h, float *f);
     LSM6DSV16XStatusTypeDef sflp2q(float quat[4], uint16_t sflp[3]);
+
+    float Convert_X_Sensitivity(lsm6dsv16x_xl_full_scale_t full_scale);
+    float Convert_G_Sensitivity(lsm6dsv16x_gy_full_scale_t full_scale);
 
     /* Helper classes. */
     TwoWire *dev_i2c;
@@ -348,17 +395,21 @@ class LSM6DSV16XSensor {
 
     lsm6dsv16x_data_rate_t acc_odr;
     lsm6dsv16x_data_rate_t gyro_odr;
+    lsm6dsv16x_xl_full_scale_t acc_fs;
+    lsm6dsv16x_gy_full_scale_t gyro_fs;
+    lsm6dsv16x_fifo_mode_t fifo_mode;
     uint8_t acc_is_enabled;
     uint8_t gyro_is_enabled;
     uint8_t initialized;
-    lsm6dsv16x_ctx_t reg_ctx;
+    stmdev_ctx_t reg_ctx;
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-int32_t LSM6DSV16X_io_write(void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite);
+int32_t LSM6DSV16X_io_write(void *handle, uint8_t WriteAddr, const uint8_t *pBuffer, uint16_t nBytesToWrite);
 int32_t LSM6DSV16X_io_read(void *handle, uint8_t ReadAddr, uint8_t *pBuffer, uint16_t nBytesToRead);
+void LSM6DSV16X_sleep(uint32_t ms);
 #ifdef __cplusplus
 }
 #endif

--- a/src/LSM6DSV16XSensor.h
+++ b/src/LSM6DSV16XSensor.h
@@ -401,7 +401,7 @@ class LSM6DSV16XSensor {
     uint8_t acc_is_enabled;
     uint8_t gyro_is_enabled;
     uint8_t initialized;
-    stmdev_ctx_t reg_ctx;
+    lsm6dsv16x_ctx_t reg_ctx;
 };
 
 #ifdef __cplusplus

--- a/src/lsm6dsv16x_reg.c
+++ b/src/lsm6dsv16x_reg.c
@@ -92,8 +92,7 @@ int32_t __weak lsm6dsv16x_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
 
 static void bytecpy(uint8_t *target, uint8_t *source)
 {
-  if ((target != NULL) && (source != NULL))
-  {
+  if ((target != NULL) && (source != NULL)) {
     *target = *source;
   }
 }
@@ -206,8 +205,7 @@ int32_t lsm6dsv16x_xl_offset_on_out_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl9.usr_off_on_out = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -255,13 +253,14 @@ int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
 
   if ((val.x_mg < (0.0078125f * 127.0f)) && (val.x_mg > (0.0078125f * -127.0f)) &&
       (val.y_mg < (0.0078125f * 127.0f)) && (val.y_mg > (0.0078125f * -127.0f)) &&
-      (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f)))
-  {
+      (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f))) {
     ctrl9.usr_off_w = 0;
 
     tmp = val.z_mg / 0.0078125f;
@@ -272,11 +271,9 @@ int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
 
     tmp = val.x_mg / 0.0078125f;
     x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
-  }
-  else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
-           (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
-           (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f)))
-  {
+  } else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
+             (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
+             (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f))) {
     ctrl9.usr_off_w = 1;
 
     tmp = val.z_mg / 0.125f;
@@ -287,9 +284,7 @@ int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
 
     tmp = val.x_mg / 0.125f;
     x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
-  }
-  else // out of limit
-  {
+  } else { // out of limit
     ctrl9.usr_off_w = 1;
     z_ofs_usr.z_ofs_usr = 0xFFU;
     y_ofs_usr.y_ofs_usr = 0xFFU;
@@ -325,16 +320,15 @@ int32_t lsm6dsv16x_xl_offset_mg_get(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  if (ctrl9.usr_off_w == PROPERTY_DISABLE)
-  {
+  if (ctrl9.usr_off_w == PROPERTY_DISABLE) {
     val->z_mg = ((float_t)z_ofs_usr.z_ofs_usr * 0.0078125f);
     val->y_mg = ((float_t)y_ofs_usr.y_ofs_usr * 0.0078125f);
     val->x_mg = ((float_t)x_ofs_usr.x_ofs_usr * 0.0078125f);
-  }
-  else
-  {
+  } else {
     val->z_mg = ((float_t)z_ofs_usr.z_ofs_usr * 0.125f);
     val->y_mg = ((float_t)y_ofs_usr.y_ofs_usr * 0.125f);
     val->x_mg = ((float_t)x_ofs_usr.x_ofs_usr * 0.125f);
@@ -364,7 +358,9 @@ int32_t lsm6dsv16x_reset_set(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ctrl3.boot = ((uint8_t)val & 0x04U) >> 2;
   ctrl3.sw_reset = ((uint8_t)val & 0x02U) >> 1;
@@ -392,10 +388,11 @@ int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch ((ctrl3.sw_reset << 2) + (ctrl3.boot << 1) + func_cfg_access.sw_por)
-  {
+  switch ((ctrl3.sw_reset << 2) + (ctrl3.boot << 1) + func_cfg_access.sw_por) {
     case LSM6DSV16X_READY:
       *val = LSM6DSV16X_READY;
       break;
@@ -434,7 +431,9 @@ int32_t lsm6dsv16x_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   func_cfg_access.shub_reg_access = ((uint8_t)val & 0x02U) >> 1;
   func_cfg_access.emb_func_reg_access = (uint8_t)val & 0x01U;
@@ -457,10 +456,11 @@ int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch ((func_cfg_access.shub_reg_access << 1) + func_cfg_access.emb_func_reg_access)
-  {
+  switch ((func_cfg_access.shub_reg_access << 1) + func_cfg_access.emb_func_reg_access) {
     case LSM6DSV16X_MAIN_MEM_BANK:
       *val = LSM6DSV16X_MAIN_MEM_BANK;
       break;
@@ -516,15 +516,18 @@ int32_t lsm6dsv16x_xl_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ctrl1.odr_xl = (uint8_t)val & 0x0Fu;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   sel = ((uint8_t)val >> 4) & 0xFU;
-  if (sel != 0U)
-  {
+  if (sel != 0U) {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
     haodr.haodr_sel = sel;
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
@@ -551,12 +554,13 @@ int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   sel = haodr.haodr_sel;
 
-  switch (ctrl1.odr_xl)
-  {
+  switch (ctrl1.odr_xl) {
     case LSM6DSV16X_ODR_OFF:
       *val = LSM6DSV16X_ODR_OFF;
       break;
@@ -571,151 +575,151 @@ int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
 
     case LSM6DSV16X_ODR_AT_15Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_15Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_15Hz625;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_12Hz5;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_15Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_15Hz625;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_12Hz5;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_30Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_30Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_31Hz25;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_25Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_30Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_31Hz25;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_25Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_60Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_60Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_62Hz5;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_50Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_60Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_62Hz5;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_50Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_120Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_120Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_125Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_100Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_120Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_125Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_100Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_240Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_240Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_250Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_200Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_240Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_250Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_200Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_480Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_480Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_500Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_400Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_480Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_500Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_400Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_960Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_960Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_1000Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_800Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_960Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_1000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_800Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_1920Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_1920Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_2000Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_1600Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_1920Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_2000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_1600Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_3840Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_3840Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_4000Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_3200Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_3840Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_4000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_3200Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_7680Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_7680Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_8000Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_6400Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_7680Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_8000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_6400Hz;
+          break;
       }
       break;
 
@@ -742,8 +746,7 @@ int32_t lsm6dsv16x_xl_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl1.op_mode_xl = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
   }
@@ -765,10 +768,11 @@ int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl1.op_mode_xl)
-  {
+  switch (ctrl1.op_mode_xl) {
     case LSM6DSV16X_XL_HIGH_PERFORMANCE_MD:
       *val = LSM6DSV16X_XL_HIGH_PERFORMANCE_MD;
       break;
@@ -824,11 +828,12 @@ int32_t lsm6dsv16x_gy_data_rate_set(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
   ctrl2.odr_g = (uint8_t)val & 0x0Fu;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   sel = ((uint8_t)val >> 4) & 0xFU;
-  if (sel != 0U)
-  {
+  if (sel != 0U) {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
     haodr.haodr_sel = sel;
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
@@ -855,12 +860,13 @@ int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   sel = haodr.haodr_sel;
 
-  switch (ctrl2.odr_g)
-  {
+  switch (ctrl2.odr_g) {
     case LSM6DSV16X_ODR_OFF:
       *val = LSM6DSV16X_ODR_OFF;
       break;
@@ -875,151 +881,151 @@ int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
 
     case LSM6DSV16X_ODR_AT_15Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_15Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_15Hz625;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_12Hz5;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_15Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_15Hz625;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_12Hz5;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_30Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_30Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_31Hz25;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_25Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_30Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_31Hz25;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_25Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_60Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_60Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_62Hz5;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_50Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_60Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_62Hz5;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_50Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_120Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_120Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_125Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_100Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_120Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_125Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_100Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_240Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_240Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_250Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_200Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_240Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_250Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_200Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_480Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_480Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_500Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_400Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_480Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_500Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_400Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_960Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_960Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_1000Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_800Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_960Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_1000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_800Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_1920Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_1920Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_2000Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_1600Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_1920Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_2000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_1600Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_3840Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_3840Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_4000Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_3200Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_3840Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_4000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_3200Hz;
+          break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_7680Hz:
       switch (sel) {
-      default:
-      case 0:
-        *val = LSM6DSV16X_ODR_AT_7680Hz;
-        break;
-      case 1:
-        *val = LSM6DSV16X_ODR_HA01_AT_8000Hz;
-        break;
-      case 2:
-        *val = LSM6DSV16X_ODR_HA02_AT_6400Hz;
-        break;
+        default:
+        case 0:
+          *val = LSM6DSV16X_ODR_AT_7680Hz;
+          break;
+        case 1:
+          *val = LSM6DSV16X_ODR_HA01_AT_8000Hz;
+          break;
+        case 2:
+          *val = LSM6DSV16X_ODR_HA02_AT_6400Hz;
+          break;
       }
       break;
 
@@ -1045,8 +1051,7 @@ int32_t lsm6dsv16x_gy_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl2.op_mode_g = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
   }
@@ -1068,10 +1073,11 @@ int32_t lsm6dsv16x_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl2.op_mode_g)
-  {
+  switch (ctrl2.op_mode_g) {
     case LSM6DSV16X_GY_HIGH_PERFORMANCE_MD:
       *val = LSM6DSV16X_GY_HIGH_PERFORMANCE_MD;
       break;
@@ -1110,8 +1116,7 @@ int32_t lsm6dsv16x_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl3.if_inc = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
@@ -1153,8 +1158,7 @@ int32_t lsm6dsv16x_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl3.bdu = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
@@ -1200,8 +1204,7 @@ int32_t lsm6dsv16x_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     odr_trig.odr_trig_nodr = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
   }
@@ -1244,8 +1247,7 @@ int32_t lsm6dsv16x_data_ready_mode_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl4.drdy_pulsed = (uint8_t)val & 0x1U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
   }
@@ -1269,8 +1271,7 @@ int32_t lsm6dsv16x_data_ready_mode_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
 
-  switch (ctrl4.drdy_pulsed)
-  {
+  switch (ctrl4.drdy_pulsed) {
     case LSM6DSV16X_DRDY_LATCHED:
       *val = LSM6DSV16X_DRDY_LATCHED;
       break;
@@ -1305,7 +1306,9 @@ int32_t lsm6dsv16x_interrupt_enable_set(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
   func.interrupts_enable = val.enable;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
   cfg.lir = val.lir;
@@ -1331,7 +1334,9 @@ int32_t lsm6dsv16x_interrupt_enable_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->enable = func.interrupts_enable;
   val->lir = cfg.lir;
@@ -1355,8 +1360,7 @@ int32_t lsm6dsv16x_gy_full_scale_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl6.fs_g = (uint8_t)val & 0xfu;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
   }
@@ -1379,10 +1383,11 @@ int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl6.fs_g)
-  {
+  switch (ctrl6.fs_g) {
     case LSM6DSV16X_125dps:
       *val = LSM6DSV16X_125dps;
       break;
@@ -1431,8 +1436,7 @@ int32_t lsm6dsv16x_xl_full_scale_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl8.fs_xl = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
   }
@@ -1455,10 +1459,11 @@ int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl8.fs_xl)
-  {
+  switch (ctrl8.fs_xl) {
     case LSM6DSV16X_2g:
       *val = LSM6DSV16X_2g;
       break;
@@ -1498,8 +1503,7 @@ int32_t lsm6dsv16x_xl_dual_channel_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl8.xl_dualc_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
   }
@@ -1542,8 +1546,7 @@ int32_t lsm6dsv16x_xl_self_test_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl10.st_xl = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
@@ -1566,10 +1569,11 @@ int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl10.st_xl)
-  {
+  switch (ctrl10.st_xl) {
     case LSM6DSV16X_XL_ST_DISABLE:
       *val = LSM6DSV16X_XL_ST_DISABLE;
       break;
@@ -1606,8 +1610,7 @@ int32_t lsm6dsv16x_gy_self_test_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl10.st_g = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
@@ -1630,10 +1633,11 @@ int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl10.st_g)
-  {
+  switch (ctrl10.st_g) {
     case LSM6DSV16X_GY_ST_DISABLE:
       *val = LSM6DSV16X_GY_ST_DISABLE;
       break;
@@ -1670,8 +1674,7 @@ int32_t lsm6dsv16x_ois_xl_self_test_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     spi2_int_ois.st_xl_ois = ((uint8_t)val & 0x3U);
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
   }
@@ -1694,10 +1697,11 @@ int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (spi2_int_ois.st_xl_ois)
-  {
+  switch (spi2_int_ois.st_xl_ois) {
     case LSM6DSV16X_OIS_XL_ST_DISABLE:
       *val = LSM6DSV16X_OIS_XL_ST_DISABLE;
       break;
@@ -1734,8 +1738,7 @@ int32_t lsm6dsv16x_ois_gy_self_test_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     spi2_int_ois.st_g_ois = ((uint8_t)val & 0x3U);
     spi2_int_ois.st_ois_clampdis = ((uint8_t)val & 0x04U) >> 2;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
@@ -1759,10 +1762,11 @@ int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (spi2_int_ois.st_g_ois)
-  {
+  switch (spi2_int_ois.st_g_ois) {
     case LSM6DSV16X_OIS_GY_ST_DISABLE:
       *val = LSM6DSV16X_OIS_GY_ST_DISABLE;
       break;
@@ -1807,7 +1811,9 @@ int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   int1_ctrl.int1_drdy_xl       = val->drdy_xl;
   int1_ctrl.int1_drdy_g        = val->drdy_g;
@@ -1817,10 +1823,14 @@ int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
   int1_ctrl.int1_cnt_bdr       = val->cnt_bdr;
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   md1_cfg.int1_shub            = val->shub;
   md1_cfg.int1_emb_func        = val->emb_func;
@@ -1852,7 +1862,9 @@ int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->drdy_xl   = int1_ctrl.int1_drdy_xl;
   val->drdy_g    = int1_ctrl.int1_drdy_g;
@@ -1862,7 +1874,9 @@ int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
   val->cnt_bdr   = int1_ctrl.int1_cnt_bdr;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->shub         = md1_cfg.int1_shub;
   val->emb_func     = md1_cfg.int1_emb_func;
@@ -1892,7 +1906,9 @@ int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   int2_ctrl.int2_drdy_xl          = val->drdy_xl;
   int2_ctrl.int2_drdy_g           = val->drdy_g;
@@ -1904,10 +1920,14 @@ int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
   int2_ctrl.int2_emb_func_endop   = val->emb_func_endop;
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   md2_cfg.int2_timestamp       = val->timestamp;
   md2_cfg.int2_emb_func        = val->emb_func;
@@ -1939,7 +1959,9 @@ int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->drdy_xl        = int2_ctrl.int2_drdy_xl;
   val->drdy_g         = int2_ctrl.int2_drdy_g;
@@ -1951,7 +1973,9 @@ int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
   val->emb_func_endop = int2_ctrl.int2_emb_func_endop;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->timestamp      = md2_cfg.int2_timestamp;
   val->emb_func       = md2_cfg.int2_emb_func;
@@ -2001,10 +2025,14 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   functions_enable.dis_rst_lir_all_int = PROPERTY_ENABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_STATUS1, (uint8_t *)&buff, 4);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   bytecpy((uint8_t *)&fifo_status2, &buff[1]);
   bytecpy((uint8_t *)&all_int_src, &buff[2]);
@@ -2030,10 +2058,14 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   functions_enable.dis_rst_lir_all_int = PROPERTY_DISABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_STATUS_REG_OIS, (uint8_t *)&buff, 8);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   bytecpy((uint8_t *)&status_reg_ois, &buff[0]);
   bytecpy((uint8_t *)&wake_up_src, &buff[1]);
@@ -2089,7 +2121,9 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EXEC_STATUS, (uint8_t *)&emb_func_exec_status, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->emb_func_stand_by = emb_func_exec_status.emb_func_endop;
   val->emb_func_time_exceed = emb_func_exec_status.emb_func_exec_ovr;
@@ -2101,7 +2135,9 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
 
   /* sensor hub */
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STATUS_MASTER_MAINPAGE, (uint8_t *)&status_shub, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->sh_endop = status_shub.sens_hub_endop;
   val->sh_wr_once = status_shub.wr_once_done;
@@ -2120,7 +2156,9 @@ int32_t lsm6dsv16x_flag_data_ready_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STATUS_REG, (uint8_t *)&status, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->drdy_xl = status.xlda;
   val->drdy_gy = status.gda;
@@ -2177,7 +2215,9 @@ int32_t lsm6dsv16x_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUT_TEMP_L, &buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
@@ -2199,7 +2239,9 @@ int32_t lsm6dsv16x_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUTX_L_G, &buff[0], 6);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -2225,7 +2267,9 @@ int32_t lsm6dsv16x_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_OUTX_L_G_OIS, &buff[0], 6);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val[0] = (int16_t)buff[1];
   val[0] = (*val * 256) + (int16_t)buff[0];
@@ -2251,7 +2295,9 @@ int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_OUTX_L_G_OIS_EIS, &buff[0], 6);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val[0] = (int16_t)buff[1];
   val[0] = (*val * 256) + (int16_t)buff[0];
@@ -2277,7 +2323,9 @@ int32_t lsm6dsv16x_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUTX_L_A, &buff[0], 6);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -2303,7 +2351,9 @@ int32_t lsm6dsv16x_dual_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_OUTX_L_A_OIS_DUALC, &buff[0], 6);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -2329,7 +2379,9 @@ int32_t lsm6dsv16x_ah_qvar_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_AH_QVAR_OUT_L, &buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
@@ -2379,53 +2431,67 @@ int32_t lsm6dsv16x_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   /* set page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_DISABLE;
   page_rw.page_write = PROPERTY_ENABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   /* select page */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   /* set page addr */
   page_address.page_addr = lsb;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_ADDRESS,
                               (uint8_t *)&page_address, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
-  for (i = 0; ((i < len) && (ret == 0)); i++)
-  {
+  for (i = 0; ((i < len) && (ret == 0)); i++) {
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_VALUE, &buf[i], 1);
-    if (ret != 0) { goto exit; }
+    if (ret != 0) {
+      goto exit;
+    }
 
     lsb++;
 
     /* Check if page wrap */
-    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
-    {
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0)) {
       msb++;
       ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      if (ret != 0) { goto exit; }
+      if (ret != 0) {
+        goto exit;
+      }
 
       page_sel.page_sel = msb;
       page_sel.not_used0 = 1; // Default value
       ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      if (ret != 0) { goto exit; }
+      if (ret != 0) {
+        goto exit;
+      }
     }
   }
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   /* unset page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
@@ -2469,53 +2535,67 @@ int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   /* set page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_ENABLE;
   page_rw.page_write = PROPERTY_DISABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   /* select page */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   /* set page addr */
   page_address.page_addr = lsb;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_ADDRESS,
                               (uint8_t *)&page_address, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
-  for (i = 0; ((i < len) && (ret == 0)); i++)
-  {
+  for (i = 0; ((i < len) && (ret == 0)); i++) {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_VALUE, &buf[i], 1);
-    if (ret != 0) { goto exit; }
+    if (ret != 0) {
+      goto exit;
+    }
 
     lsb++;
 
     /* Check if page wrap */
-    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
-    {
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0)) {
       msb++;
       ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      if (ret != 0) { goto exit; }
+      if (ret != 0) {
+        goto exit;
+      }
 
       page_sel.page_sel = msb;
       page_sel.not_used0 = 1; // Default value
       ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      if (ret != 0) { goto exit; }
+      if (ret != 0) {
+        goto exit;
+      }
     }
   }
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   /* unset page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
@@ -2544,8 +2624,7 @@ int32_t lsm6dsv16x_emb_function_dbg_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl10.emb_func_debug = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
@@ -2567,7 +2646,9 @@ int32_t lsm6dsv16x_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = ctrl10.emb_func_debug;
 
@@ -2603,8 +2684,7 @@ int32_t lsm6dsv16x_den_polarity_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl4.int2_in_lh = (uint8_t)val & 0x1U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
   }
@@ -2627,10 +2707,11 @@ int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl4.int2_in_lh)
-  {
+  switch (ctrl4.int2_in_lh) {
     case LSM6DSV16X_DEN_ACT_LOW:
       *val = LSM6DSV16X_DEN_ACT_LOW;
       break;
@@ -2661,7 +2742,9 @@ int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_DEN, (uint8_t *)&den, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   den.den_z = val.den_z;
   den.den_y = val.den_y;
@@ -2670,23 +2753,16 @@ int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val)
   den.lvl2_en = (uint8_t)val.mode & 0x1U;
   den.lvl1_en = ((uint8_t)val.mode & 0x2U) >> 1;
 
-  if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
-  {
+  if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_ENABLE) {
     den.den_xl_g = PROPERTY_DISABLE;
     den.den_xl_en = PROPERTY_ENABLE;
-  }
-  else if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_DISABLE)
-  {
+  } else if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_DISABLE) {
     den.den_xl_g = PROPERTY_DISABLE;
     den.den_xl_en = PROPERTY_DISABLE;
-  }
-  else if (val.stamp_in_gy_data == PROPERTY_DISABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
-  {
+  } else if (val.stamp_in_gy_data == PROPERTY_DISABLE && val.stamp_in_xl_data == PROPERTY_ENABLE) {
     den.den_xl_g = PROPERTY_ENABLE;
     den.den_xl_en = PROPERTY_DISABLE;
-  }
-  else
-  {
+  } else {
     den.den_xl_g = PROPERTY_DISABLE;
     den.den_xl_en = PROPERTY_DISABLE;
     den.den_z = PROPERTY_DISABLE;
@@ -2716,38 +2792,31 @@ int32_t lsm6dsv16x_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_DEN, (uint8_t *)&den, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->den_z = den.den_z;
   val->den_y = den.den_y;
   val->den_x = den.den_x;
 
-  if ((den.den_x | den.den_y | den.den_z) == PROPERTY_ENABLE)
-  {
-    if (den.den_xl_g == PROPERTY_DISABLE && den.den_xl_en == PROPERTY_ENABLE)
-    {
+  if ((den.den_x | den.den_y | den.den_z) == PROPERTY_ENABLE) {
+    if (den.den_xl_g == PROPERTY_DISABLE && den.den_xl_en == PROPERTY_ENABLE) {
       val->stamp_in_gy_data = PROPERTY_ENABLE;
       val->stamp_in_xl_data = PROPERTY_ENABLE;
-    }
-    else if (den.den_xl_g == PROPERTY_DISABLE && den.den_xl_en == PROPERTY_DISABLE)
-    {
+    } else if (den.den_xl_g == PROPERTY_DISABLE && den.den_xl_en == PROPERTY_DISABLE) {
       val->stamp_in_gy_data = PROPERTY_ENABLE;
       val->stamp_in_xl_data = PROPERTY_DISABLE;
-    }
-    else // ( (den.den_xl_g & !den.den_xl_en) == PROPERTY_ENABLE )
-    {
+    } else { // ( (den.den_xl_g & !den.den_xl_en) == PROPERTY_ENABLE )
       val->stamp_in_gy_data = PROPERTY_DISABLE;
       val->stamp_in_xl_data = PROPERTY_ENABLE;
     }
-  }
-  else
-  {
+  } else {
     val->stamp_in_gy_data = PROPERTY_DISABLE;
     val->stamp_in_xl_data = PROPERTY_DISABLE;
   }
 
-  switch ((den.lvl1_en << 1) + den.lvl2_en)
-  {
+  switch ((den.lvl1_en << 1) + den.lvl2_en) {
     case LEVEL_TRIGGER:
       val->mode = LEVEL_TRIGGER;
       break;
@@ -2792,8 +2861,7 @@ int32_t lsm6dsv16x_eis_gy_full_scale_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl_eis.fs_g_eis = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
@@ -2816,10 +2884,11 @@ int32_t lsm6dsv16x_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl_eis.fs_g_eis)
-  {
+  switch (ctrl_eis.fs_g_eis) {
     case LSM6DSV16X_EIS_125dps:
       *val = LSM6DSV16X_EIS_125dps;
       break;
@@ -2862,8 +2931,7 @@ int32_t lsm6dsv16x_eis_gy_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl_eis.g_eis_on_g_ois_out_reg = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
@@ -2906,8 +2974,7 @@ int32_t lsm6dsv16x_gy_eis_data_rate_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl_eis.odr_g_eis = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
@@ -2930,10 +2997,11 @@ int32_t lsm6dsv16x_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl_eis.odr_g_eis)
-  {
+  switch (ctrl_eis.odr_g_eis) {
     case LSM6DSV16X_EIS_ODR_OFF:
       *val = LSM6DSV16X_EIS_ODR_OFF;
       break;
@@ -2981,8 +3049,7 @@ int32_t lsm6dsv16x_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl1.wtm = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
   }
@@ -3023,8 +3090,7 @@ int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl2.xl_dualc_batch_from_fsm = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
@@ -3066,8 +3132,7 @@ int32_t lsm6dsv16x_fifo_compress_algo_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl2.uncompr_rate = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
@@ -3090,10 +3155,11 @@ int32_t lsm6dsv16x_fifo_compress_algo_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (fifo_ctrl2.uncompr_rate)
-  {
+  switch (fifo_ctrl2.uncompr_rate) {
     case LSM6DSV16X_CMP_DISABLE:
       *val = LSM6DSV16X_CMP_DISABLE;
       break;
@@ -3131,8 +3197,7 @@ int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl2.odr_chg_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
@@ -3179,10 +3244,14 @@ int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   fifo_ctrl2.fifo_compr_rt_en = val;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
   emb_func_en_b.fifo_compr_en = val;
@@ -3227,8 +3296,7 @@ int32_t lsm6dsv16x_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl2.stop_on_wtm = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
@@ -3270,8 +3338,7 @@ int32_t lsm6dsv16x_fifo_xl_batch_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl3.bdr_xl = (uint8_t)val & 0xFu;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
   }
@@ -3294,10 +3361,11 @@ int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (fifo_ctrl3.bdr_xl)
-  {
+  switch (fifo_ctrl3.bdr_xl) {
     case LSM6DSV16X_XL_NOT_BATCHED:
       *val = LSM6DSV16X_XL_NOT_BATCHED;
       break;
@@ -3373,8 +3441,7 @@ int32_t lsm6dsv16x_fifo_gy_batch_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl3.bdr_gy = (uint8_t)val & 0x0Fu;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
   }
@@ -3397,10 +3464,11 @@ int32_t lsm6dsv16x_fifo_gy_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (fifo_ctrl3.bdr_gy)
-  {
+  switch (fifo_ctrl3.bdr_gy) {
     case LSM6DSV16X_GY_NOT_BATCHED:
       *val = LSM6DSV16X_GY_NOT_BATCHED;
       break;
@@ -3475,8 +3543,7 @@ int32_t lsm6dsv16x_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl4.fifo_mode = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
@@ -3498,10 +3565,11 @@ int32_t lsm6dsv16x_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (fifo_ctrl4.fifo_mode)
-  {
+  switch (fifo_ctrl4.fifo_mode) {
     case LSM6DSV16X_BYPASS_MODE:
       *val = LSM6DSV16X_BYPASS_MODE;
       break;
@@ -3551,8 +3619,7 @@ int32_t lsm6dsv16x_fifo_gy_eis_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl4.g_eis_fifo_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
@@ -3594,8 +3661,7 @@ int32_t lsm6dsv16x_fifo_temp_batch_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl4.odr_t_batch = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
@@ -3618,10 +3684,11 @@ int32_t lsm6dsv16x_fifo_temp_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (fifo_ctrl4.odr_t_batch)
-  {
+  switch (fifo_ctrl4.odr_t_batch) {
     case LSM6DSV16X_TEMP_NOT_BATCHED:
       *val = LSM6DSV16X_TEMP_NOT_BATCHED;
       break;
@@ -3660,8 +3727,7 @@ int32_t lsm6dsv16x_fifo_timestamp_batch_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fifo_ctrl4.dec_ts_batch = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
@@ -3684,10 +3750,11 @@ int32_t lsm6dsv16x_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (fifo_ctrl4.dec_ts_batch)
-  {
+  switch (fifo_ctrl4.dec_ts_batch) {
     case LSM6DSV16X_TMSTMP_NOT_BATCHED:
       *val = LSM6DSV16X_TMSTMP_NOT_BATCHED;
       break;
@@ -3748,7 +3815,9 @@ int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, &buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -3771,8 +3840,7 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     counter_bdr_reg1.trig_counter_bdr = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
   }
@@ -3795,10 +3863,11 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (counter_bdr_reg1.trig_counter_bdr)
-  {
+  switch (counter_bdr_reg1.trig_counter_bdr) {
     case LSM6DSV16X_XL_BATCH_EVENT:
       *val = LSM6DSV16X_XL_BATCH_EVENT;
       break;
@@ -3827,7 +3896,9 @@ int32_t lsm6dsv16x_fifo_status_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_STATUS1, (uint8_t *)&buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   bytecpy((uint8_t *)&status, &buff[1]);
 
@@ -3866,12 +3937,13 @@ int32_t lsm6dsv16x_fifo_out_raw_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_DATA_OUT_TAG, buff, 7);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   bytecpy((uint8_t *)&fifo_data_out_tag, &buff[0]);
 
-  switch (fifo_data_out_tag.tag_sensor)
-  {
+  switch (fifo_data_out_tag.tag_sensor) {
     case LSM6DSV16X_FIFO_EMPTY:
       val->tag = LSM6DSV16X_FIFO_EMPTY;
       break;
@@ -4015,7 +4087,9 @@ int32_t lsm6dsv16x_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   emb_func_fifo_en_a.step_counter_fifo_en = val;
@@ -4040,7 +4114,9 @@ int32_t lsm6dsv16x_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   *val = emb_func_fifo_en_a.step_counter_fifo_en;
@@ -4064,7 +4140,9 @@ int32_t lsm6dsv16x_fifo_mlc_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   emb_func_fifo_en_a.mlc_fifo_en = val;
@@ -4089,7 +4167,9 @@ int32_t lsm6dsv16x_fifo_mlc_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   *val = emb_func_fifo_en_a.mlc_fifo_en;
@@ -4113,7 +4193,9 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
   emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
@@ -4138,7 +4220,9 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
   *val = emb_func_fifo_en_b.mlc_filter_feature_fifo_en;
@@ -4162,11 +4246,13 @@ int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U, (uint8_t *)&slv_config, 1);
   slv_config.batch_ext_sens_0_en = val;
-  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U, (uint8_t *)&slv_config, 1);
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
@@ -4187,9 +4273,11 @@ int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U, (uint8_t *)&slv_config, 1);
   *val = slv_config.batch_ext_sens_0_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -4212,8 +4300,7 @@ int32_t lsm6dsv16x_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
     emb_func_fifo_en_a.sflp_game_fifo_en = val.game_rotation;
     emb_func_fifo_en_a.sflp_gravity_fifo_en = val.gravity;
@@ -4242,8 +4329,7 @@ int32_t lsm6dsv16x_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
 
     val->game_rotation = emb_func_fifo_en_a.sflp_game_fifo_en;
@@ -4285,8 +4371,7 @@ int32_t lsm6dsv16x_filt_anti_spike_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     if_cfg.asf_ctrl = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -4309,10 +4394,11 @@ int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (if_cfg.asf_ctrl)
-  {
+  switch (if_cfg.asf_ctrl) {
     case LSM6DSV16X_AUTO:
       *val = LSM6DSV16X_AUTO;
       break;
@@ -4348,13 +4434,17 @@ int32_t lsm6dsv16x_filt_settling_mask_set(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
   ctrl4.drdy_mask = val.drdy;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
   emb_func_cfg.emb_func_irq_mask_xl_settl = val.irq_xl;
   emb_func_cfg.emb_func_irq_mask_g_settl = val.irq_g;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
   ui_int_ois.drdy_mask_ois = val.ois_drdy;
@@ -4406,8 +4496,7 @@ int32_t lsm6dsv16x_filt_ois_settling_mask_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     spi2_int_ois.drdy_mask_ois = val.ois_drdy;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
   }
@@ -4451,8 +4540,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl6.lpf1_g_bw = (uint8_t)val & 0x0Fu;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
   }
@@ -4475,10 +4563,11 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl6.lpf1_g_bw)
-  {
+  switch (ctrl6.lpf1_g_bw) {
     case LSM6DSV16X_GY_ULTRA_LIGHT:
       *val = LSM6DSV16X_GY_ULTRA_LIGHT;
       break;
@@ -4533,8 +4622,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl7.lpf1_g_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
@@ -4577,8 +4665,7 @@ int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl8.hp_lpf2_xl_bw = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
   }
@@ -4601,10 +4688,11 @@ int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl8.hp_lpf2_xl_bw)
-  {
+  switch (ctrl8.hp_lpf2_xl_bw) {
     case LSM6DSV16X_XL_ULTRA_LIGHT:
       *val = LSM6DSV16X_XL_ULTRA_LIGHT;
       break;
@@ -4659,8 +4747,7 @@ int32_t lsm6dsv16x_filt_xl_lp2_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl9.lpf2_xl_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -4701,8 +4788,7 @@ int32_t lsm6dsv16x_filt_xl_hp_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl9.hp_slope_xl_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -4743,8 +4829,7 @@ int32_t lsm6dsv16x_filt_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl9.xl_fastsettl_mode = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -4786,8 +4871,7 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl9.hp_ref_mode_xl = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -4810,10 +4894,11 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl9.hp_ref_mode_xl)
-  {
+  switch (ctrl9.hp_ref_mode_xl) {
     case LSM6DSV16X_HP_MD_NORMAL:
       *val = LSM6DSV16X_HP_MD_NORMAL;
       break;
@@ -4847,11 +4932,15 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   tap_cfg0.slope_fds = (uint8_t)val & 0x01U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   wake_up_ths.usr_off_on_wu = ((uint8_t)val & 0x02U) >> 1;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
@@ -4876,10 +4965,11 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch ((wake_up_ths.usr_off_on_wu << 1) + tap_cfg0.slope_fds)
-  {
+  switch ((wake_up_ths.usr_off_on_wu << 1) + tap_cfg0.slope_fds) {
     case LSM6DSV16X_WK_FEED_SLOPE:
       *val = LSM6DSV16X_WK_FEED_SLOPE;
       break;
@@ -4915,8 +5005,7 @@ int32_t lsm6dsv16x_mask_trigger_xl_settl_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     tap_cfg0.hw_func_mask_xl_settl = val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
   }
@@ -4959,8 +5048,7 @@ int32_t lsm6dsv16x_filt_sixd_feed_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     tap_cfg0.low_pass_on_6d = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
   }
@@ -4983,10 +5071,11 @@ int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (tap_cfg0.low_pass_on_6d)
-  {
+  switch (tap_cfg0.low_pass_on_6d) {
     case LSM6DSV16X_SIXD_FEED_ODR_DIV_2:
       *val = LSM6DSV16X_SIXD_FEED_ODR_DIV_2;
       break;
@@ -5019,8 +5108,7 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl_eis.lpf_g_eis_bw = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
@@ -5043,10 +5131,11 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl_eis.lpf_g_eis_bw)
-  {
+  switch (ctrl_eis.lpf_g_eis_bw) {
     case LSM6DSV16X_EIS_LP_NORMAL:
       *val = LSM6DSV16X_EIS_LP_NORMAL;
       break;
@@ -5079,8 +5168,7 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ui_ctrl2_ois.lpf1_g_ois_bw = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
   }
@@ -5104,10 +5192,11 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ui_ctrl2_ois.lpf1_g_ois_bw)
-  {
+  switch (ui_ctrl2_ois.lpf1_g_ois_bw) {
     case LSM6DSV16X_OIS_GY_LP_NORMAL:
       *val = LSM6DSV16X_OIS_GY_LP_NORMAL;
       break;
@@ -5148,8 +5237,7 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ui_ctrl3_ois.lpf_xl_ois_bw = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
   }
@@ -5172,10 +5260,11 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ui_ctrl3_ois.lpf_xl_ois_bw)
-  {
+  switch (ui_ctrl3_ois.lpf_xl_ois_bw) {
     case LSM6DSV16X_OIS_XL_LP_ULTRA_LIGHT:
       *val = LSM6DSV16X_OIS_XL_LP_ULTRA_LIGHT;
       break;
@@ -5245,8 +5334,7 @@ int32_t lsm6dsv16x_fsm_permission_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     func_cfg_access.fsm_wr_ctrl_en = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
@@ -5269,10 +5357,11 @@ int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (func_cfg_access.fsm_wr_ctrl_en)
-  {
+  switch (func_cfg_access.fsm_wr_ctrl_en) {
     case LSM6DSV16X_PROTECT_CTRL_REGS:
       *val = LSM6DSV16X_PROTECT_CTRL_REGS;
       break;
@@ -5324,19 +5413,20 @@ int32_t lsm6dsv16x_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   if ((val.fsm1_en | val.fsm2_en | val.fsm3_en | val.fsm4_en
-       | val.fsm5_en | val.fsm6_en | val.fsm7_en | val.fsm8_en) == PROPERTY_ENABLE)
-  {
+       | val.fsm5_en | val.fsm6_en | val.fsm7_en | val.fsm8_en) == PROPERTY_ENABLE) {
     emb_func_en_b.fsm_en = PROPERTY_ENABLE;
-  }
-  else
-  {
+  } else {
     emb_func_en_b.fsm_en = PROPERTY_DISABLE;
   }
 
@@ -5374,7 +5464,9 @@ int32_t lsm6dsv16x_fsm_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->fsm1_en = fsm_enable.fsm1_en;
   val->fsm2_en = fsm_enable.fsm2_en;
@@ -5427,7 +5519,9 @@ int32_t lsm6dsv16x_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_LONG_COUNTER_L, &buff[0], 2);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -5470,7 +5564,9 @@ int32_t lsm6dsv16x_fsm_data_rate_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   fsm_odr.fsm_odr = (uint8_t)val & 0x07U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
@@ -5498,10 +5594,11 @@ int32_t lsm6dsv16x_fsm_data_rate_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (fsm_odr.fsm_odr)
-  {
+  switch (fsm_odr.fsm_odr) {
     case LSM6DSV16X_FSM_15Hz:
       *val = LSM6DSV16X_FSM_15Hz;
       break;
@@ -5555,31 +5652,23 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
   f_exp = (f & 0x7f800000u);
 
   /* Exponent overflow/NaN converts to signed inf/NaN */
-  if (f_exp >= 0x47800000u)
-  {
-    if (f_exp == 0x7f800000u)
-    {
+  if (f_exp >= 0x47800000u) {
+    if (f_exp == 0x7f800000u) {
       /* Inf or NaN */
       f_sig = (f & 0x007fffffu);
-      if (f_sig != 0U)
-      {
+      if (f_sig != 0U) {
         /* NaN - propagate the flag in the significand... */
         uint16_t ret = (uint16_t)(0x7c00u + (f_sig >> 13));
         /* ...but make sure it stays a NaN */
-        if (ret == 0x7c00u)
-        {
+        if (ret == 0x7c00u) {
           ret++;
         }
         return h_sgn + ret;
-      }
-      else
-      {
+      } else {
         /* signed inf */
         return (uint16_t)(h_sgn + 0x7c00u);
       }
-    }
-    else
-    {
+    } else {
       /* overflow to signed inf */
 #if NPY_HALF_GENERATE_OVERFLOW
       npy_set_floatstatus_overflow();
@@ -5589,18 +5678,15 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
   }
 
   /* Exponent underflow converts to a subnormal half or signed zero */
-  if (f_exp <= 0x38000000u)
-  {
+  if (f_exp <= 0x38000000u) {
     /*
      * Signed zeros, subnormal floats, and floats with small
      * exponents all convert to signed zero half-floats.
      */
-    if (f_exp < 0x33000000u)
-    {
+    if (f_exp < 0x33000000u) {
 #if NPY_HALF_GENERATE_UNDERFLOW
       /* If f != 0, it underflowed to 0 */
-      if ((f & 0x7fffffff) != 0)
-      {
+      if ((f & 0x7fffffff) != 0) {
         npy_set_floatstatus_underflow();
       }
 #endif
@@ -5611,8 +5697,7 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
     f_sig = (0x00800000u + (f & 0x007fffffu));
 #if NPY_HALF_GENERATE_UNDERFLOW
     /* If it's not exactly represented, it underflowed */
-    if ((f_sig & (((uint32_t)1 << (126 - f_exp)) - 1)) != 0)
-    {
+    if ((f_sig & (((uint32_t)1 << (126 - f_exp)) - 1)) != 0) {
       npy_set_floatstatus_underflow();
     }
 #endif
@@ -5632,8 +5717,7 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
      * shift can lose up to 11 bits, so the || checks them in the original.
      * In all other cases, we can just add one.
      */
-    if (((f_sig & 0x00003fffu) != 0x00001000u) || (f & 0x000007ffu))
-    {
+    if (((f_sig & 0x00003fffu) != 0x00001000u) || (f & 0x000007ffu)) {
       f_sig += 0x00001000u;
     }
 #else
@@ -5658,8 +5742,7 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
    * the remaining bit pattern is 1000...0, then we do not add one
    * to the bit after the half significand.  In all other cases, we do.
    */
-  if ((f_sig & 0x00003fffu) != 0x00001000u)
-  {
+  if ((f_sig & 0x00003fffu) != 0x00001000u) {
     f_sig += 0x00001000u;
   }
 #else
@@ -5674,8 +5757,7 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
    */
 #if NPY_HALF_GENERATE_OVERFLOW
   h_sig += h_exp;
-  if (h_sig == 0x7c00u)
-  {
+  if (h_sig == 0x7c00u) {
     npy_set_floatstatus_overflow();
   }
   return h_sgn + h_sig;
@@ -5686,8 +5768,7 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
 
 static uint16_t npy_float_to_half(float_t f)
 {
-  union
-  {
+  union {
     float_t f;
     uint32_t fbits;
   } conv;
@@ -5726,11 +5807,12 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_sflp_data_rate_get(ctx, &sflp_odr);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   /* Calculate k factor */
-  switch (sflp_odr)
-  {
+  switch (sflp_odr) {
     default:
     case LSM6DSV16X_SFLP_15Hz:
       k = 0.04f;
@@ -5761,8 +5843,7 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, conf_saved, 2);
   ret += lsm6dsv16x_xl_mode_set(ctx, LSM6DSV16X_XL_HIGH_PERFORMANCE_MD);
   ret += lsm6dsv16x_gy_mode_set(ctx, LSM6DSV16X_GY_HIGH_PERFORMANCE_MD);
-  if (((uint8_t)conf_saved[0] & 0x0FU) == (uint8_t)LSM6DSV16X_ODR_OFF)
-  {
+  if (((uint8_t)conf_saved[0] & 0x0FU) == (uint8_t)LSM6DSV16X_ODR_OFF) {
     ret += lsm6dsv16x_xl_data_rate_set(ctx, LSM6DSV16X_ODR_AT_120Hz);
   }
 
@@ -5774,8 +5855,7 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, emb_func_en_saved, 2);
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, reg_zero, 2);
-  do
-  {
+  do {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EXEC_STATUS,
                                (uint8_t *)&emb_func_sts, 1);
   } while (emb_func_sts.emb_func_endop != 1U);
@@ -5796,16 +5876,14 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_xl_full_scale_get(ctx, &xl_fs);
 
   /* Read XL data */
-  do
-  {
+  do {
     ret += lsm6dsv16x_flag_data_ready_get(ctx, &drdy);
   } while (drdy.drdy_xl != 1U);
   ret += lsm6dsv16x_acceleration_raw_get(ctx, xl_data);
 
   /* force sflp initialization */
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  for (i = 0; i < 3U; i++)
-  {
+  for (i = 0; i < 3U; i++) {
     j = 0;
     data_tmp = (int32_t)xl_data[i];
     data_tmp <<= xl_fs; // shift based on current fs
@@ -5816,8 +5894,7 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SENSOR_HUB_3 + 3U * i, &data_ptr[j],
                                 1);
   }
-  for (i = 0; i < 3U; i++)
-  {
+  for (i = 0; i < 3U; i++) {
     j = 0;
     data_tmp = 0;
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SENSOR_HUB_10 + 3U * i,
@@ -5832,8 +5909,7 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
   // wait end_op (and at least 30 us)
   ctx->mdelay(1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  do
-  {
+  do {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EXEC_STATUS,
                                (uint8_t *)&emb_func_sts, 1);
   } while (emb_func_sts.emb_func_endop != 1U);
@@ -5891,7 +5967,9 @@ int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_SENSITIVITY_L, &buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -5939,7 +6017,9 @@ int32_t lsm6dsv16x_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_OFFX_L, &buff[0], 6);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->x = buff[1];
   val->x = (val->x * 256U) + buff[0];
@@ -5997,7 +6077,9 @@ int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_MATRIX_XX_L, &buff[0], 12);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->xx = buff[1];
   val->xx = (val->xx * 256U) + buff[0];
@@ -6051,10 +6133,11 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ext_cfg_a.ext_z_axis)
-  {
+  switch (ext_cfg_a.ext_z_axis) {
     case LSM6DSV16X_Z_EQ_Y:
       *val = LSM6DSV16X_Z_EQ_Y;
       break;
@@ -6102,8 +6185,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ext_cfg_a.ext_y_axis = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
   }
@@ -6126,10 +6208,11 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ext_cfg_a.ext_y_axis)
-  {
+  switch (ext_cfg_a.ext_y_axis) {
     case LSM6DSV16X_Y_EQ_Y:
       *val = LSM6DSV16X_Y_EQ_Y;
       break;
@@ -6177,8 +6260,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ext_cfg_b.ext_x_axis = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
   }
@@ -6201,10 +6283,11 @@ int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ext_cfg_b.ext_x_axis)
-  {
+  switch (ext_cfg_b.ext_x_axis) {
     case LSM6DSV16X_X_EQ_Y:
       *val = LSM6DSV16X_X_EQ_Y;
       break;
@@ -6271,7 +6354,9 @@ int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_LC_TIMEOUT_L, &buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -6293,8 +6378,7 @@ int32_t lsm6dsv16x_fsm_number_of_programs_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_PROGRAMS, (uint8_t *)&fsm_programs, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     fsm_programs.fsm_n_prog = val;
     ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_PROGRAMS, (uint8_t *)&fsm_programs, 1);
   }
@@ -6355,7 +6439,9 @@ int32_t lsm6dsv16x_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_START_ADD_L, &buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -6393,7 +6479,9 @@ int32_t lsm6dsv16x_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
   wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
   free_fall.ff_dur = (uint8_t)val & 0x1FU;
@@ -6439,8 +6527,7 @@ int32_t lsm6dsv16x_ff_thresholds_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     free_fall.ff_ths = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
   }
@@ -6463,10 +6550,11 @@ int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (free_fall.ff_ths)
-  {
+  switch (free_fall.ff_ths) {
     case LSM6DSV16X_156_mg:
       *val = LSM6DSV16X_156_mg;
       break;
@@ -6537,10 +6625,11 @@ int32_t lsm6dsv16x_mlc_set(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
-  switch(val)
-  {
+  switch (val) {
     case LSM6DSV16X_MLC_OFF:
       emb_en_a.mlc_before_fsm_en = 0;
       emb_en_b.mlc_en = 0;
@@ -6583,23 +6672,18 @@ int32_t lsm6dsv16x_mlc_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
-  if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U)
-  {
+  if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U) {
     *val = LSM6DSV16X_MLC_OFF;
-  }
-  else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U)
-  {
+  } else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U) {
     *val = LSM6DSV16X_MLC_ON;
-  }
-  else if (emb_en_a.mlc_before_fsm_en == 1U)
-  {
+  } else if (emb_en_a.mlc_before_fsm_en == 1U) {
     *val = LSM6DSV16X_MLC_ON_BEFORE_FSM;
-  }
-  else
-  {
-      /* Do nothing */
+  } else {
+    /* Do nothing */
   }
 
 exit:
@@ -6624,7 +6708,9 @@ int32_t lsm6dsv16x_mlc_data_rate_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   mlc_odr.mlc_odr = (uint8_t)val & 0x07U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
@@ -6652,10 +6738,11 @@ int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (mlc_odr.mlc_odr)
-  {
+  switch (mlc_odr.mlc_odr) {
     case LSM6DSV16X_MLC_15Hz:
       *val = LSM6DSV16X_MLC_15Hz;
       break;
@@ -6705,8 +6792,7 @@ int32_t lsm6dsv16x_mlc_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC1_SRC, (uint8_t *)val, 4);
   }
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -6750,7 +6836,9 @@ int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_MLC_EXT_SENSITIVITY_L, &buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -6786,8 +6874,7 @@ int32_t lsm6dsv16x_ois_ctrl_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     func_cfg_access.ois_ctrl_from_ui = (uint8_t)val & 0x1U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
@@ -6810,10 +6897,11 @@ int32_t lsm6dsv16x_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (func_cfg_access.ois_ctrl_from_ui)
-  {
+  switch (func_cfg_access.ois_ctrl_from_ui) {
     case LSM6DSV16X_OIS_CTRL_FROM_OIS:
       *val = LSM6DSV16X_OIS_CTRL_FROM_OIS;
       break;
@@ -6844,8 +6932,7 @@ int32_t lsm6dsv16x_ois_reset_set(stmdev_ctx_t *ctx, int8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     func_cfg_access.spi2_reset = (uint8_t)val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
@@ -6886,8 +6973,7 @@ int32_t lsm6dsv16x_ois_interface_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     pin_ctrl.ois_pu_dis = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
@@ -6929,8 +7015,7 @@ int32_t lsm6dsv16x_ois_handshake_from_ui_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ui_handshake_ctrl.ui_shared_ack = val.ack;
     ui_handshake_ctrl.ui_shared_req = val.req;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
@@ -6954,7 +7039,9 @@ int32_t lsm6dsv16x_ois_handshake_from_ui_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->ack = ui_handshake_ctrl.ui_shared_ack;
   val->req = ui_handshake_ctrl.ui_shared_req;
@@ -6977,8 +7064,7 @@ int32_t lsm6dsv16x_ois_handshake_from_ois_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_HANDSHAKE_CTRL, (uint8_t *)&spi2_handshake_ctrl, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     spi2_handshake_ctrl.spi2_shared_ack = val.ack;
     spi2_handshake_ctrl.spi2_shared_req = val.req;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SPI2_HANDSHAKE_CTRL, (uint8_t *)&spi2_handshake_ctrl, 1);
@@ -7002,7 +7088,9 @@ int32_t lsm6dsv16x_ois_handshake_from_ois_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_HANDSHAKE_CTRL, (uint8_t *)&spi2_handshake_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->ack = spi2_handshake_ctrl.spi2_shared_ack;
   val->req = spi2_handshake_ctrl.spi2_shared_req;
@@ -7058,8 +7146,7 @@ int32_t lsm6dsv16x_ois_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ui_ctrl1_ois.spi2_read_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
   }
@@ -7100,8 +7187,7 @@ int32_t lsm6dsv16x_ois_chain_set(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ui_ctrl1_ois.ois_g_en = val.gy;
     ui_ctrl1_ois.ois_xl_en = val.xl;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
@@ -7124,7 +7210,9 @@ int32_t lsm6dsv16x_ois_chain_get(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->gy = ui_ctrl1_ois.ois_g_en;
   val->xl = ui_ctrl1_ois.ois_xl_en;
@@ -7147,8 +7235,7 @@ int32_t lsm6dsv16x_ois_gy_full_scale_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ui_ctrl2_ois.fs_g_ois = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
   }
@@ -7171,10 +7258,11 @@ int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ui_ctrl2_ois.fs_g_ois)
-  {
+  switch (ui_ctrl2_ois.fs_g_ois) {
     case LSM6DSV16X_OIS_125dps:
       *val = LSM6DSV16X_OIS_125dps;
       break;
@@ -7218,8 +7306,7 @@ int32_t lsm6dsv16x_ois_xl_full_scale_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ui_ctrl3_ois.fs_xl_ois = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
   }
@@ -7242,10 +7329,11 @@ int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ui_ctrl3_ois.fs_xl_ois)
-  {
+  switch (ui_ctrl3_ois.fs_xl_ois) {
     case LSM6DSV16X_OIS_2g:
       *val = LSM6DSV16X_OIS_2g;
       break;
@@ -7298,8 +7386,7 @@ int32_t lsm6dsv16x_6d_threshold_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     tap_ths_6d.sixd_ths = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   }
@@ -7322,10 +7409,11 @@ int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (tap_ths_6d.sixd_ths)
-  {
+  switch (tap_ths_6d.sixd_ths) {
     case LSM6DSV16X_DEG_80:
       *val = LSM6DSV16X_DEG_80;
       break;
@@ -7364,8 +7452,7 @@ int32_t lsm6dsv16x_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     tap_ths_6d.d4d_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   }
@@ -7420,8 +7507,7 @@ int32_t lsm6dsv16x_ah_qvar_zin_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl7.ah_qvar_c_zin = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
@@ -7444,10 +7530,11 @@ int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl7.ah_qvar_c_zin)
-  {
+  switch (ctrl7.ah_qvar_c_zin) {
     case LSM6DSV16X_2400MOhm:
       *val = LSM6DSV16X_2400MOhm;
       break;
@@ -7487,8 +7574,7 @@ int32_t lsm6dsv16x_ah_qvar_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl7.ah_qvar_en = val.ah_qvar_en;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
@@ -7544,8 +7630,7 @@ int32_t lsm6dsv16x_i3c_reset_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     pin_ctrl.ibhr_por_en = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
@@ -7568,10 +7653,11 @@ int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (pin_ctrl.ibhr_por_en)
-  {
+  switch (pin_ctrl.ibhr_por_en) {
     case LSM6DSV16X_SW_RST_DYN_ADDRESS_RST:
       *val = LSM6DSV16X_SW_RST_DYN_ADDRESS_RST;
       break;
@@ -7603,8 +7689,7 @@ int32_t lsm6dsv16x_i3c_ibi_time_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL5, (uint8_t *)&ctrl5, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ctrl5.bus_act_sel = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL5, (uint8_t *)&ctrl5, 1);
   }
@@ -7627,10 +7712,11 @@ int32_t lsm6dsv16x_i3c_ibi_time_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL5, (uint8_t *)&ctrl5, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ctrl5.bus_act_sel)
-  {
+  switch (ctrl5.bus_act_sel) {
     case LSM6DSV16X_IBI_2us:
       *val = LSM6DSV16X_IBI_2us;
       break;
@@ -7683,8 +7769,7 @@ int32_t lsm6dsv16x_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     if_cfg.shub_pu_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -7748,7 +7833,9 @@ int32_t lsm6dsv16x_sh_slave_connected_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   master_config.aux_sens_on = (uint8_t)val & 0x3U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -7776,10 +7863,11 @@ int32_t lsm6dsv16x_sh_slave_connected_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (master_config.aux_sens_on)
-  {
+  switch (master_config.aux_sens_on) {
     case LSM6DSV16X_SLV_0:
       *val = LSM6DSV16X_SLV_0;
       break;
@@ -7819,7 +7907,9 @@ int32_t lsm6dsv16x_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   master_config.master_on = val;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -7868,7 +7958,9 @@ int32_t lsm6dsv16x_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   master_config.pass_through_mode = val;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -7918,7 +8010,9 @@ int32_t lsm6dsv16x_sh_syncro_mode_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   master_config.start_config = (uint8_t)val & 0x01U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -7946,10 +8040,11 @@ int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (master_config.start_config)
-  {
+  switch (master_config.start_config) {
     case LSM6DSV16X_SH_TRG_XL_GY_DRDY:
       *val = LSM6DSV16X_SH_TRG_XL_GY_DRDY;
       break;
@@ -7982,7 +8077,9 @@ int32_t lsm6dsv16x_sh_write_mode_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   master_config.write_once = (uint8_t)val & 0x01U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -8010,10 +8107,11 @@ int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (master_config.write_once)
-  {
+  switch (master_config.write_once) {
     case LSM6DSV16X_EACH_SH_CYCLE:
       *val = LSM6DSV16X_EACH_SH_CYCLE;
       break;
@@ -8045,7 +8143,9 @@ int32_t lsm6dsv16x_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   master_config.rst_master_regs = val;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -8097,16 +8197,22 @@ int32_t lsm6dsv16x_sh_cfg_write(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   reg.slave0_add = val->slv0_add;
   reg.rw_0 = 0;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD, (uint8_t *)&reg, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD,
                              &(val->slv0_subadd), 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_DATAWRITE_SLV0,
                              &(val->slv0_data), 1);
@@ -8133,7 +8239,9 @@ int32_t lsm6dsv16x_sh_data_rate_set(stmdev_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   slv0_config.shub_odr = (uint8_t)val & 0x07U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
@@ -8161,10 +8269,11 @@ int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (slv0_config.shub_odr)
-  {
+  switch (slv0_config.shub_odr) {
     case LSM6DSV16X_SH_15Hz:
       *val = LSM6DSV16X_SH_15Hz;
       break;
@@ -8216,24 +8325,32 @@ int32_t lsm6dsv16x_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   slv_add.slave0_add = val->slv_add;
   slv_add.rw_0 = 1;
-  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD + idx*3U,
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD + idx * 3U,
                              (uint8_t *)&slv_add, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
-  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD + idx*3U,
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD + idx * 3U,
                              &(val->slv_subadd), 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
-  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U,
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U,
                             (uint8_t *)&slv_config, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   slv_config.slave0_numop = val->slv_len;
-  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U,
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U,
                              (uint8_t *)&slv_config, 1);
 
 exit:
@@ -8287,8 +8404,7 @@ int32_t lsm6dsv16x_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     pin_ctrl.sdo_pu_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
@@ -8330,8 +8446,7 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     if_cfg.i2c_i3c_disable = (uint8_t)val & 0x1U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -8354,10 +8469,11 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (if_cfg.i2c_i3c_disable)
-  {
+  switch (if_cfg.i2c_i3c_disable) {
     case LSM6DSV16X_I2C_I3C_ENABLE:
       *val = LSM6DSV16X_I2C_I3C_ENABLE;
       break;
@@ -8388,8 +8504,7 @@ int32_t lsm6dsv16x_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     if_cfg.sim = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -8411,10 +8526,11 @@ int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (if_cfg.sim)
-  {
+  switch (if_cfg.sim) {
     case LSM6DSV16X_SPI_4_WIRE:
       *val = LSM6DSV16X_SPI_4_WIRE;
       break;
@@ -8445,8 +8561,7 @@ int32_t lsm6dsv16x_ui_sda_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     if_cfg.sda_pu_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -8474,7 +8589,7 @@ int32_t lsm6dsv16x_ui_sda_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  SPI2 (OIS Inteface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = SPI2_CTRL1_OIS).[set]
+  * @brief  SPI2 (OIS Interface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = SPI2_CTRL1_OIS).[set]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      SPI2_4_WIRE, SPI2_3_WIRE,
@@ -8487,8 +8602,7 @@ int32_t lsm6dsv16x_spi2_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ui_ctrl1_ois.sim_ois = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
   }
@@ -8497,7 +8611,7 @@ int32_t lsm6dsv16x_spi2_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val)
 }
 
 /**
-  * @brief  SPI2 (OIS Inteface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = SPI2_CTRL1_OIS).[get]
+  * @brief  SPI2 (OIS Interface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = SPI2_CTRL1_OIS).[get]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      SPI2_4_WIRE, SPI2_3_WIRE,
@@ -8510,10 +8624,11 @@ int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (ui_ctrl1_ois.sim_ois)
-  {
+  switch (ui_ctrl1_ois.sim_ois) {
     case LSM6DSV16X_SPI2_4_WIRE:
       *val = LSM6DSV16X_SPI2_4_WIRE;
       break;
@@ -8558,7 +8673,9 @@ int32_t lsm6dsv16x_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   emb_func_en_a.sign_motion_en = val;
@@ -8583,7 +8700,9 @@ int32_t lsm6dsv16x_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.sign_motion_en;
@@ -8622,16 +8741,19 @@ int32_t lsm6dsv16x_stpcnt_mode_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   if ((val.false_step_rej == PROPERTY_ENABLE)
       && ((emb_func_en_a.mlc_before_fsm_en & emb_func_en_b.mlc_en) ==
-          PROPERTY_DISABLE))
-  {
+          PROPERTY_DISABLE)) {
     emb_func_en_a.mlc_before_fsm_en = PROPERTY_ENABLE;
   }
 
@@ -8641,8 +8763,7 @@ int32_t lsm6dsv16x_stpcnt_mode_set(stmdev_ctx_t *ctx,
 exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
-  if (ret == 0)
-  {
+  if (ret == 0) {
     ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
     pedo_cmd_reg.fp_rejection_en = val.false_step_rej;
     ret += lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
@@ -8669,10 +8790,14 @@ int32_t lsm6dsv16x_stpcnt_mode_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->false_step_rej = pedo_cmd_reg.fp_rejection_en;
   val->step_counter_enable = emb_func_en_a.pedo_en;
@@ -8696,7 +8821,9 @@ int32_t lsm6dsv16x_stpcnt_steps_get(stmdev_ctx_t *ctx, uint16_t *val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STEP_COUNTER_L, &buff[0], 2);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -8718,10 +8845,14 @@ int32_t lsm6dsv16x_stpcnt_rst_step_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   emb_func_src.pedo_rst_step = val;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
@@ -8746,7 +8877,9 @@ int32_t lsm6dsv16x_stpcnt_rst_step_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   *val = emb_func_src.pedo_rst_step;
@@ -8770,8 +8903,7 @@ int32_t lsm6dsv16x_stpcnt_debounce_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_DEB_STEPS_CONF, (uint8_t *)&pedo_deb_steps_conf, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     pedo_deb_steps_conf.deb_step = val;
     ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_DEB_STEPS_CONF, (uint8_t *)&pedo_deb_steps_conf, 1);
   }
@@ -8832,7 +8964,9 @@ int32_t lsm6dsv16x_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_SC_DELTAT_L, &buff[0], 2);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -8866,10 +9000,14 @@ int32_t lsm6dsv16x_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   emb_func_en_a.sflp_game_en = val;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A,
@@ -8895,7 +9033,9 @@ int32_t lsm6dsv16x_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.sflp_game_en;
@@ -8920,10 +9060,14 @@ int32_t lsm6dsv16x_sflp_data_rate_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
-  if (ret != 0) { goto exit; }
+  if (ret != 0) {
+    goto exit;
+  }
 
   sflp_odr.sflp_game_odr = (uint8_t)val & 0x07U;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
@@ -8951,10 +9095,11 @@ int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (sflp_odr.sflp_game_odr)
-  {
+  switch (sflp_odr.sflp_game_odr) {
     case LSM6DSV16X_SFLP_15Hz:
       *val = LSM6DSV16X_SFLP_15Hz;
       break;
@@ -9015,8 +9160,7 @@ int32_t lsm6dsv16x_tap_detection_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     tap_cfg0.tap_x_en = val.tap_x_en;
     tap_cfg0.tap_y_en = val.tap_y_en;
     tap_cfg0.tap_z_en = val.tap_z_en;
@@ -9041,7 +9185,9 @@ int32_t lsm6dsv16x_tap_detection_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->tap_x_en = tap_cfg0.tap_x_en;
   val->tap_y_en = tap_cfg0.tap_y_en;
@@ -9069,7 +9215,9 @@ int32_t lsm6dsv16x_tap_thresholds_set(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   tap_cfg1.tap_ths_x = val.x;
   tap_cfg2.tap_ths_y = val.y;
@@ -9101,7 +9249,9 @@ int32_t lsm6dsv16x_tap_thresholds_get(stmdev_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->x  = tap_cfg1.tap_ths_x;
   val->y = tap_cfg2.tap_ths_y;
@@ -9125,8 +9275,7 @@ int32_t lsm6dsv16x_tap_axis_priority_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     tap_cfg1.tap_priority = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
   }
@@ -9149,10 +9298,11 @@ int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (tap_cfg1.tap_priority)
-  {
+  switch (tap_cfg1.tap_priority) {
     case LSM6DSV16X_XYZ :
       *val = LSM6DSV16X_XYZ ;
       break;
@@ -9200,8 +9350,7 @@ int32_t lsm6dsv16x_tap_time_windows_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_DUR, (uint8_t *)&tap_dur, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     tap_dur.shock = val.shock;
     tap_dur.quiet = val.quiet;
     tap_dur.dur = val.tap_gap;
@@ -9226,7 +9375,9 @@ int32_t lsm6dsv16x_tap_time_windows_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_DUR, (uint8_t *)&tap_dur, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->shock = tap_dur.shock;
   val->quiet = tap_dur.quiet;
@@ -9249,8 +9400,7 @@ int32_t lsm6dsv16x_tap_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     wake_up_ths.single_double_tap = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   }
@@ -9272,10 +9422,11 @@ int32_t lsm6dsv16x_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (wake_up_ths.single_double_tap)
-  {
+  switch (wake_up_ths.single_double_tap) {
     case LSM6DSV16X_ONLY_SINGLE:
       *val = LSM6DSV16X_ONLY_SINGLE;
       break;
@@ -9319,7 +9470,9 @@ int32_t lsm6dsv16x_tilt_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   emb_func_en_a.tilt_en = val;
@@ -9344,7 +9497,9 @@ int32_t lsm6dsv16x_tilt_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.tilt_en;
@@ -9381,7 +9536,9 @@ int32_t lsm6dsv16x_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TIMESTAMP0, &buff[0], 4);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   *val = buff[3];
   *val = (*val * 256U) + buff[2];
@@ -9405,8 +9562,7 @@ int32_t lsm6dsv16x_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     functions_enable.timestamp_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   }
@@ -9460,8 +9616,7 @@ int32_t lsm6dsv16x_act_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     functions_enable.inact_en = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   }
@@ -9483,10 +9638,11 @@ int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val)
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (functions_enable.inact_en)
-  {
+  switch (functions_enable.inact_en) {
     case LSM6DSV16X_XL_AND_GY_NOT_AFFECTED:
       *val = LSM6DSV16X_XL_AND_GY_NOT_AFFECTED;
       break;
@@ -9526,8 +9682,7 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     inactivity_dur.inact_dur = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
   }
@@ -9550,10 +9705,11 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (inactivity_dur.inact_dur)
-  {
+  switch (inactivity_dur.inact_dur) {
     case LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE:
       *val = LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE;
       break;
@@ -9593,8 +9749,7 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     inactivity_dur.xl_inact_odr = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
   }
@@ -9617,10 +9772,11 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
-  switch (inactivity_dur.xl_inact_odr)
-  {
+  switch (inactivity_dur.xl_inact_odr) {
     case LSM6DSV16X_1Hz875:
       *val = LSM6DSV16X_1Hz875;
       break;
@@ -9666,7 +9822,9 @@ int32_t lsm6dsv16x_act_thresholds_set(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
   inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
@@ -9705,7 +9863,9 @@ int32_t lsm6dsv16x_act_thresholds_get(stmdev_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->inactivity_cfg.wu_inact_ths_w = inactivity_dur.wu_inact_ths_w;
   val->inactivity_cfg.xl_inact_odr = inactivity_dur.xl_inact_odr;
@@ -9733,8 +9893,7 @@ int32_t lsm6dsv16x_act_wkup_time_windows_set(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret == 0)
-  {
+  if (ret == 0) {
     wake_up_dur.wake_dur = val.shock;
     wake_up_dur.sleep_dur = val.quiet;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
@@ -9758,7 +9917,9 @@ int32_t lsm6dsv16x_act_wkup_time_windows_get(stmdev_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret != 0) { return ret; }
+  if (ret != 0) {
+    return ret;
+  }
 
   val->shock = wake_up_dur.wake_dur;
   val->quiet = wake_up_dur.sleep_dur;

--- a/src/lsm6dsv16x_reg.c
+++ b/src/lsm6dsv16x_reg.c
@@ -46,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak lsm6dsv16x_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
+int32_t __weak lsm6dsv16x_read_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
                                    uint8_t *data,
                                    uint16_t len)
 {
@@ -67,7 +67,7 @@ int32_t __weak lsm6dsv16x_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak lsm6dsv16x_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
+int32_t __weak lsm6dsv16x_write_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
                                     uint8_t *data,
                                     uint16_t len)
 {
@@ -199,7 +199,7 @@ float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_offset_on_out_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_xl_offset_on_out_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -221,7 +221,7 @@ int32_t lsm6dsv16x_xl_offset_on_out_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_offset_on_out_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_xl_offset_on_out_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -240,7 +240,7 @@ int32_t lsm6dsv16x_xl_offset_on_out_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_offset_mg_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t val)
 {
   lsm6dsv16x_z_ofs_usr_t z_ofs_usr;
@@ -307,7 +307,7 @@ int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_offset_mg_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_offset_mg_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t *val)
 {
   lsm6dsv16x_z_ofs_usr_t z_ofs_usr;
@@ -350,7 +350,7 @@ int32_t lsm6dsv16x_xl_offset_mg_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_reset_set(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val)
+int32_t lsm6dsv16x_reset_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   lsm6dsv16x_ctrl3_t ctrl3;
@@ -380,7 +380,7 @@ int32_t lsm6dsv16x_reset_set(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val)
+int32_t lsm6dsv16x_reset_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   lsm6dsv16x_ctrl3_t ctrl3;
@@ -425,7 +425,7 @@ int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t val)
+int32_t lsm6dsv16x_mem_bank_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -450,7 +450,7 @@ int32_t lsm6dsv16x_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val)
+int32_t lsm6dsv16x_mem_bank_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -490,7 +490,7 @@ int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_device_id_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_device_id_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
@@ -507,7 +507,7 @@ int32_t lsm6dsv16x_device_id_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t val)
 {
   lsm6dsv16x_ctrl1_t ctrl1;
@@ -544,7 +544,7 @@ int32_t lsm6dsv16x_xl_data_rate_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val)
 {
   lsm6dsv16x_ctrl1_t ctrl1;
@@ -739,7 +739,7 @@ int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t val)
+int32_t lsm6dsv16x_xl_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t val)
 {
   lsm6dsv16x_ctrl1_t ctrl1;
   int32_t ret;
@@ -762,7 +762,7 @@ int32_t lsm6dsv16x_xl_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
+int32_t lsm6dsv16x_xl_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
 {
   lsm6dsv16x_ctrl1_t ctrl1;
   int32_t ret;
@@ -817,7 +817,7 @@ int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t val)
 {
   lsm6dsv16x_ctrl2_t ctrl2;
@@ -850,7 +850,7 @@ int32_t lsm6dsv16x_gy_data_rate_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val)
 {
   lsm6dsv16x_ctrl2_t ctrl2;
@@ -1045,7 +1045,7 @@ int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t val)
+int32_t lsm6dsv16x_gy_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t val)
 {
   lsm6dsv16x_ctrl2_t ctrl2;
   int32_t ret;
@@ -1067,7 +1067,7 @@ int32_t lsm6dsv16x_gy_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
+int32_t lsm6dsv16x_gy_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
 {
   lsm6dsv16x_ctrl2_t ctrl2;
   int32_t ret;
@@ -1110,7 +1110,7 @@ int32_t lsm6dsv16x_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_auto_increment_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl3_t ctrl3;
   int32_t ret;
@@ -1132,7 +1132,7 @@ int32_t lsm6dsv16x_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_auto_increment_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl3_t ctrl3;
   int32_t ret;
@@ -1151,7 +1151,7 @@ int32_t lsm6dsv16x_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_block_data_update_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl3_t ctrl3;
   int32_t ret;
@@ -1174,7 +1174,7 @@ int32_t lsm6dsv16x_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_block_data_update_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl3_t ctrl3;
   int32_t ret;
@@ -1193,7 +1193,7 @@ int32_t lsm6dsv16x_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_odr_trig_cfg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_odr_trig_cfg_t odr_trig;
   int32_t ret;
@@ -1220,7 +1220,7 @@ int32_t lsm6dsv16x_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_odr_trig_cfg_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_odr_trig_cfg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_odr_trig_cfg_t odr_trig;
   int32_t ret;
@@ -1239,7 +1239,7 @@ int32_t lsm6dsv16x_odr_trig_cfg_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_data_ready_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_data_ready_mode_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t val)
 {
   lsm6dsv16x_ctrl4_t ctrl4;
@@ -1263,7 +1263,7 @@ int32_t lsm6dsv16x_data_ready_mode_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_data_ready_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_data_ready_mode_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t *val)
 {
   lsm6dsv16x_ctrl4_t ctrl4;
@@ -1296,7 +1296,7 @@ int32_t lsm6dsv16x_data_ready_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_interrupt_enable_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_interrupt_enable_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t val)
 {
   lsm6dsv16x_tap_cfg0_t cfg;
@@ -1325,7 +1325,7 @@ int32_t lsm6dsv16x_interrupt_enable_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_interrupt_enable_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_interrupt_enable_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t *val)
 {
   lsm6dsv16x_tap_cfg0_t cfg;
@@ -1352,7 +1352,7 @@ int32_t lsm6dsv16x_interrupt_enable_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t val)
 {
   lsm6dsv16x_ctrl6_t ctrl6;
@@ -1376,7 +1376,7 @@ int32_t lsm6dsv16x_gy_full_scale_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t *val)
 {
   lsm6dsv16x_ctrl6_t ctrl6;
@@ -1428,7 +1428,7 @@ int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_xl_full_scale_t val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
@@ -1452,7 +1452,7 @@ int32_t lsm6dsv16x_xl_full_scale_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_xl_full_scale_t *val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
@@ -1496,7 +1496,7 @@ int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_dual_channel_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_xl_dual_channel_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
   int32_t ret;
@@ -1519,7 +1519,7 @@ int32_t lsm6dsv16x_xl_dual_channel_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_dual_channel_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_xl_dual_channel_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
   int32_t ret;
@@ -1538,7 +1538,7 @@ int32_t lsm6dsv16x_xl_dual_channel_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_self_test_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
@@ -1562,7 +1562,7 @@ int32_t lsm6dsv16x_xl_self_test_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t *val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
@@ -1602,7 +1602,7 @@ int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_self_test_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
@@ -1626,7 +1626,7 @@ int32_t lsm6dsv16x_gy_self_test_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t *val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
@@ -1666,7 +1666,7 @@ int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_xl_self_test_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
@@ -1690,7 +1690,7 @@ int32_t lsm6dsv16x_ois_xl_self_test_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t *val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
@@ -1730,7 +1730,7 @@ int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_gy_self_test_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
@@ -1755,7 +1755,7 @@ int32_t lsm6dsv16x_ois_gy_self_test_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t *val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
@@ -1803,7 +1803,7 @@ int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int1_route_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val)
 {
   lsm6dsv16x_int1_ctrl_t          int1_ctrl;
@@ -1854,7 +1854,7 @@ int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int1_route_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val)
 {
   lsm6dsv16x_int1_ctrl_t          int1_ctrl;
@@ -1898,7 +1898,7 @@ int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int2_route_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val)
 {
   lsm6dsv16x_int2_ctrl_t          int2_ctrl;
@@ -1951,7 +1951,7 @@ int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int2_route_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val)
 {
   lsm6dsv16x_int2_ctrl_t          int2_ctrl;
@@ -2002,7 +2002,7 @@ int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_all_sources_t *val)
 {
   lsm6dsv16x_emb_func_status_mainpage_t emb_func_status_mainpage;
@@ -2149,7 +2149,7 @@ int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
   return ret;
 }
 
-int32_t lsm6dsv16x_flag_data_ready_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_flag_data_ready_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_t *val)
 {
   lsm6dsv16x_status_reg_t status;
@@ -2175,7 +2175,7 @@ int32_t lsm6dsv16x_flag_data_ready_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_int_ack_mask_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_int_ack_mask_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
 
@@ -2192,7 +2192,7 @@ int32_t lsm6dsv16x_int_ack_mask_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_int_ack_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_int_ack_mask_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
@@ -2209,7 +2209,7 @@ int32_t lsm6dsv16x_int_ack_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_temperature_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -2233,7 +2233,7 @@ int32_t lsm6dsv16x_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -2261,7 +2261,7 @@ int32_t lsm6dsv16x_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_ois_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -2289,7 +2289,7 @@ int32_t lsm6dsv16x_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -2317,7 +2317,7 @@ int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -2345,7 +2345,7 @@ int32_t lsm6dsv16x_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_dual_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_dual_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
@@ -2373,7 +2373,7 @@ int32_t lsm6dsv16x_dual_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_raw_get(stmdev_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_ah_qvar_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -2397,7 +2397,7 @@ int32_t lsm6dsv16x_ah_qvar_raw_get(stmdev_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_odr_cal_reg_get(stmdev_ctx_t *ctx, int8_t *val)
+int32_t lsm6dsv16x_odr_cal_reg_get(lsm6dsv16x_ctx_t *ctx, int8_t *val)
 {
   lsm6dsv16x_internal_freq_t internal_freq;
   int32_t ret;
@@ -2416,7 +2416,7 @@ int32_t lsm6dsv16x_odr_cal_reg_get(stmdev_ctx_t *ctx, int8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
+int32_t lsm6dsv16x_ln_pg_write(lsm6dsv16x_ctx_t *ctx, uint16_t address,
                                uint8_t *buf, uint8_t len)
 {
   lsm6dsv16x_page_address_t  page_address;
@@ -2520,7 +2520,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
+int32_t lsm6dsv16x_ln_pg_read(lsm6dsv16x_ctx_t *ctx, uint16_t address, uint8_t *buf,
                               uint8_t len)
 {
   lsm6dsv16x_page_address_t  page_address;
@@ -2617,7 +2617,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_emb_function_dbg_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_emb_function_dbg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
   int32_t ret;
@@ -2640,7 +2640,7 @@ int32_t lsm6dsv16x_emb_function_dbg_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_emb_function_dbg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
   int32_t ret;
@@ -2676,7 +2676,7 @@ int32_t lsm6dsv16x_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_den_polarity_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_den_polarity_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t val)
 {
   lsm6dsv16x_ctrl4_t ctrl4;
@@ -2700,7 +2700,7 @@ int32_t lsm6dsv16x_den_polarity_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_den_polarity_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t *val)
 {
   lsm6dsv16x_ctrl4_t ctrl4;
@@ -2736,7 +2736,7 @@ int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val)
+int32_t lsm6dsv16x_den_conf_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t val)
 {
   lsm6dsv16x_den_t den;
   int32_t ret;
@@ -2786,7 +2786,7 @@ int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t *val)
+int32_t lsm6dsv16x_den_conf_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t *val)
 {
   lsm6dsv16x_den_t den;
   int32_t ret;
@@ -2853,7 +2853,7 @@ int32_t lsm6dsv16x_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_eis_gy_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_eis_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_eis_gy_full_scale_t val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -2877,7 +2877,7 @@ int32_t lsm6dsv16x_eis_gy_full_scale_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_eis_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_eis_gy_full_scale_t *val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -2924,7 +2924,7 @@ int32_t lsm6dsv16x_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_eis_gy_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_eis_gy_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
   int32_t ret;
@@ -2947,7 +2947,7 @@ int32_t lsm6dsv16x_eis_gy_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_eis_gy_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_eis_gy_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
   int32_t ret;
@@ -2966,7 +2966,7 @@ int32_t lsm6dsv16x_eis_gy_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_eis_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_eis_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_gy_eis_data_rate_t val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -2990,7 +2990,7 @@ int32_t lsm6dsv16x_gy_eis_data_rate_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_eis_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_gy_eis_data_rate_t *val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -3042,7 +3042,7 @@ int32_t lsm6dsv16x_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_watermark_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl1_t fifo_ctrl1;
   int32_t ret;
@@ -3065,7 +3065,7 @@ int32_t lsm6dsv16x_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_watermark_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl1_t fifo_ctrl1;
   int32_t ret;
@@ -3084,7 +3084,7 @@ int32_t lsm6dsv16x_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3106,7 +3106,7 @@ int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3125,7 +3125,7 @@ int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_compress_algo_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_set(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_fifo_compress_algo_t val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
@@ -3148,7 +3148,7 @@ int32_t lsm6dsv16x_fifo_compress_algo_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_compress_algo_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_get(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_fifo_compress_algo_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
@@ -3191,7 +3191,7 @@ int32_t lsm6dsv16x_fifo_compress_algo_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3213,7 +3213,7 @@ int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(lsm6dsv16x_ctx_t *ctx,
                                                  uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
@@ -3233,7 +3233,7 @@ int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(lsm6dsv16x_ctx_t *ctx,
                                                     uint8_t val)
 {
   lsm6dsv16x_emb_func_en_b_t emb_func_en_b;
@@ -3269,7 +3269,7 @@ int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(lsm6dsv16x_ctx_t *ctx,
                                                     uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
@@ -3290,7 +3290,7 @@ int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_stop_on_wtm_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3312,7 +3312,7 @@ int32_t lsm6dsv16x_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_stop_on_wtm_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3331,7 +3331,7 @@ int32_t lsm6dsv16x_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_xl_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_xl_batch_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t val)
 {
   lsm6dsv16x_fifo_ctrl3_t fifo_ctrl3;
@@ -3354,7 +3354,7 @@ int32_t lsm6dsv16x_fifo_xl_batch_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_xl_batch_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t *val)
 {
   lsm6dsv16x_fifo_ctrl3_t fifo_ctrl3;
@@ -3434,7 +3434,7 @@ int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_gy_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_gy_batch_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t val)
 {
   lsm6dsv16x_fifo_ctrl3_t fifo_ctrl3;
@@ -3457,7 +3457,7 @@ int32_t lsm6dsv16x_fifo_gy_batch_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_gy_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_gy_batch_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t *val)
 {
   lsm6dsv16x_fifo_ctrl3_t fifo_ctrl3;
@@ -3537,7 +3537,7 @@ int32_t lsm6dsv16x_fifo_gy_batch_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val)
+int32_t lsm6dsv16x_fifo_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -3559,7 +3559,7 @@ int32_t lsm6dsv16x_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t *val)
+int32_t lsm6dsv16x_fifo_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fifo_mode_t *val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -3613,7 +3613,7 @@ int32_t lsm6dsv16x_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_gy_eis_batch_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_gy_eis_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -3635,7 +3635,7 @@ int32_t lsm6dsv16x_fifo_gy_eis_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_gy_eis_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_gy_eis_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -3654,7 +3654,7 @@ int32_t lsm6dsv16x_fifo_gy_eis_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_temp_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_temp_batch_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
@@ -3677,7 +3677,7 @@ int32_t lsm6dsv16x_fifo_temp_batch_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_temp_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_temp_batch_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t *val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
@@ -3720,7 +3720,7 @@ int32_t lsm6dsv16x_fifo_temp_batch_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_timestamp_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_timestamp_batch_set(lsm6dsv16x_ctx_t *ctx,
                                             lsm6dsv16x_fifo_timestamp_batch_t val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
@@ -3743,7 +3743,7 @@ int32_t lsm6dsv16x_fifo_timestamp_batch_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_timestamp_batch_get(lsm6dsv16x_ctx_t *ctx,
                                             lsm6dsv16x_fifo_timestamp_batch_t *val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
@@ -3787,7 +3787,7 @@ int32_t lsm6dsv16x_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(lsm6dsv16x_ctx_t *ctx,
                                                     uint16_t val)
 {
   uint8_t buff[2];
@@ -3808,7 +3808,7 @@ int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(lsm6dsv16x_ctx_t *ctx,
                                                     uint16_t *val)
 {
   uint8_t buff[2];
@@ -3833,7 +3833,7 @@ int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_cnt_event_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_cnt_event_set(lsm6dsv16x_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t val)
 {
   lsm6dsv16x_counter_bdr_reg1_t counter_bdr_reg1;
@@ -3856,7 +3856,7 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_cnt_event_get(lsm6dsv16x_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t *val)
 {
   lsm6dsv16x_counter_bdr_reg1_t counter_bdr_reg1;
@@ -3888,7 +3888,7 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
   return ret;
 }
 
-int32_t lsm6dsv16x_fifo_status_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_status_get(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_fifo_status_t *val)
 {
   uint8_t buff[2];
@@ -3929,7 +3929,7 @@ int32_t lsm6dsv16x_fifo_status_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_out_raw_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_out_raw_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_fifo_out_raw_t *val)
 {
   lsm6dsv16x_fifo_data_out_tag_t fifo_data_out_tag;
@@ -4081,7 +4081,7 @@ int32_t lsm6dsv16x_fifo_out_raw_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_stpcnt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
@@ -4108,7 +4108,7 @@ int32_t lsm6dsv16x_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_stpcnt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
@@ -4134,7 +4134,7 @@ int32_t lsm6dsv16x_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mlc_batch_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_mlc_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
@@ -4161,7 +4161,7 @@ int32_t lsm6dsv16x_fifo_mlc_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mlc_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_mlc_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
@@ -4187,7 +4187,7 @@ int32_t lsm6dsv16x_fifo_mlc_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
   int32_t ret;
@@ -4214,7 +4214,7 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
   int32_t ret;
@@ -4240,7 +4240,7 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val)
+int32_t lsm6dsv16x_fifo_sh_batch_slave_set(lsm6dsv16x_ctx_t *ctx, uint8_t idx, uint8_t val)
 {
   lsm6dsv16x_slv0_config_t slv_config;
   int32_t ret;
@@ -4267,7 +4267,7 @@ int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_sh_batch_slave_get(lsm6dsv16x_ctx_t *ctx, uint8_t idx, uint8_t *val)
 {
   lsm6dsv16x_slv0_config_t slv_config;
   int32_t ret;
@@ -4293,7 +4293,7 @@ int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_sflp_batch_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
@@ -4322,7 +4322,7 @@ int32_t lsm6dsv16x_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_sflp_batch_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t *val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
@@ -4363,7 +4363,7 @@ int32_t lsm6dsv16x_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_anti_spike_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_anti_spike_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
@@ -4387,7 +4387,7 @@ int32_t lsm6dsv16x_filt_anti_spike_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_anti_spike_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
@@ -4423,7 +4423,7 @@ int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_settling_mask_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t val)
 {
   lsm6dsv16x_emb_func_cfg_t emb_func_cfg;
@@ -4461,7 +4461,7 @@ int32_t lsm6dsv16x_filt_settling_mask_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_settling_mask_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t *val)
 {
   lsm6dsv16x_emb_func_cfg_t emb_func_cfg;
@@ -4488,7 +4488,7 @@ int32_t lsm6dsv16x_filt_settling_mask_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_ois_settling_mask_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_ois_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
@@ -4512,7 +4512,7 @@ int32_t lsm6dsv16x_filt_ois_settling_mask_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_ois_settling_mask_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_ois_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t *val)
 {
 
@@ -4533,7 +4533,7 @@ int32_t lsm6dsv16x_filt_ois_settling_mask_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_filt_gy_lp1_bandwidth_t val)
 {
   lsm6dsv16x_ctrl6_t ctrl6;
@@ -4556,7 +4556,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_filt_gy_lp1_bandwidth_t *val)
 {
   lsm6dsv16x_ctrl6_t ctrl6;
@@ -4616,7 +4616,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_lp1_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_filt_gy_lp1_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
   int32_t ret;
@@ -4639,7 +4639,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_lp1_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_filt_gy_lp1_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
   int32_t ret;
@@ -4658,7 +4658,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_filt_xl_lp2_bandwidth_t val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
@@ -4681,7 +4681,7 @@ int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_filt_xl_lp2_bandwidth_t *val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
@@ -4741,7 +4741,7 @@ int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_lp2_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_filt_xl_lp2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4763,7 +4763,7 @@ int32_t lsm6dsv16x_filt_xl_lp2_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_lp2_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_filt_xl_lp2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4782,7 +4782,7 @@ int32_t lsm6dsv16x_filt_xl_lp2_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_hp_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_filt_xl_hp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4804,7 +4804,7 @@ int32_t lsm6dsv16x_filt_xl_hp_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_hp_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_filt_xl_hp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4823,7 +4823,7 @@ int32_t lsm6dsv16x_filt_xl_hp_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_filt_xl_fast_settling_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4845,7 +4845,7 @@ int32_t lsm6dsv16x_filt_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_filt_xl_fast_settling_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4864,7 +4864,7 @@ int32_t lsm6dsv16x_filt_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_hp_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_hp_mode_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
@@ -4887,7 +4887,7 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_hp_mode_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
@@ -4923,7 +4923,7 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_wkup_act_feed_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_wkup_act_feed_set(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_filt_wkup_act_feed_t val)
 {
   lsm6dsv16x_wake_up_ths_t wake_up_ths;
@@ -4956,7 +4956,7 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_wkup_act_feed_get(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_filt_wkup_act_feed_t *val)
 {
   lsm6dsv16x_wake_up_ths_t wake_up_ths;
@@ -4998,7 +4998,7 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mask_trigger_xl_settl_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_mask_trigger_xl_settl_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5021,7 +5021,7 @@ int32_t lsm6dsv16x_mask_trigger_xl_settl_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mask_trigger_xl_settl_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_mask_trigger_xl_settl_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5040,7 +5040,7 @@ int32_t lsm6dsv16x_mask_trigger_xl_settl_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_sixd_feed_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_sixd_feed_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
@@ -5064,7 +5064,7 @@ int32_t lsm6dsv16x_filt_sixd_feed_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_sixd_feed_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t *val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
@@ -5100,7 +5100,7 @@ int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -5124,7 +5124,7 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t *val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -5160,7 +5160,7 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t val)
 {
   lsm6dsv16x_ui_ctrl2_ois_t ui_ctrl2_ois;
@@ -5184,7 +5184,7 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t *val)
 {
 
@@ -5229,7 +5229,7 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t val)
 {
   lsm6dsv16x_ui_ctrl3_ois_t ui_ctrl3_ois;
@@ -5253,7 +5253,7 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t *val)
 {
   lsm6dsv16x_ui_ctrl3_ois_t ui_ctrl3_ois;
@@ -5326,7 +5326,7 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_permission_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_permission_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
@@ -5350,7 +5350,7 @@ int32_t lsm6dsv16x_fsm_permission_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_permission_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
@@ -5386,7 +5386,7 @@ int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_permission_status(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fsm_permission_status(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl_status_t ctrl_status;
   int32_t ret;
@@ -5406,7 +5406,7 @@ int32_t lsm6dsv16x_fsm_permission_status(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val)
+int32_t lsm6dsv16x_fsm_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val)
 {
   lsm6dsv16x_emb_func_en_b_t emb_func_en_b;
   lsm6dsv16x_fsm_enable_t fsm_enable;
@@ -5456,7 +5456,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val)
+int32_t lsm6dsv16x_fsm_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val)
 {
   lsm6dsv16x_fsm_enable_t fsm_enable;
   int32_t ret;
@@ -5488,7 +5488,7 @@ int32_t lsm6dsv16x_fsm_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_fsm_long_cnt_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -5511,7 +5511,7 @@ int32_t lsm6dsv16x_fsm_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_fsm_long_cnt_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -5537,7 +5537,7 @@ int32_t lsm6dsv16x_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val)
+int32_t lsm6dsv16x_fsm_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val)
 {
   int32_t ret;
 
@@ -5556,7 +5556,7 @@ int32_t lsm6dsv16x_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fsm_data_rate_t val)
 {
   lsm6dsv16x_fsm_odr_t fsm_odr;
@@ -5585,7 +5585,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fsm_data_rate_t *val)
 {
   lsm6dsv16x_fsm_odr_t fsm_odr;
@@ -5786,7 +5786,7 @@ static uint16_t npy_float_to_half(float_t f)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_sflp_gbias_t *val)
 {
   lsm6dsv16x_sflp_data_rate_t sflp_odr;
@@ -5940,7 +5940,7 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -5960,7 +5960,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(stmdev_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
                                                 uint16_t *val)
 {
   uint8_t buff[2];
@@ -5985,7 +5985,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_offset_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_offset_set(lsm6dsv16x_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t val)
 {
   uint8_t buff[6];
@@ -6010,7 +6010,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_offset_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_offset_get(lsm6dsv16x_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t *val)
 {
   uint8_t buff[6];
@@ -6039,7 +6039,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(lsm6dsv16x_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t val)
 {
   uint8_t buff[12];
@@ -6070,7 +6070,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(lsm6dsv16x_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t *val)
 {
   uint8_t buff[12];
@@ -6105,7 +6105,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t val)
 {
   lsm6dsv16x_ext_cfg_a_t ext_cfg_a;
@@ -6126,7 +6126,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t *val)
 {
   lsm6dsv16x_ext_cfg_a_t ext_cfg_a;
@@ -6178,7 +6178,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t val)
 {
   lsm6dsv16x_ext_cfg_a_t ext_cfg_a;
@@ -6201,7 +6201,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t *val)
 {
   lsm6dsv16x_ext_cfg_a_t ext_cfg_a;
@@ -6253,7 +6253,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_x_orient_t val)
 {
   lsm6dsv16x_ext_cfg_b_t ext_cfg_b;
@@ -6276,7 +6276,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_x_orient_t *val)
 {
   lsm6dsv16x_ext_cfg_b_t ext_cfg_b;
@@ -6328,7 +6328,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -6348,7 +6348,7 @@ int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(stmdev_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -6372,7 +6372,7 @@ int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(stmdev_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_number_of_programs_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fsm_number_of_programs_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fsm_programs_t fsm_programs;
   int32_t ret;
@@ -6394,7 +6394,7 @@ int32_t lsm6dsv16x_fsm_number_of_programs_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_number_of_programs_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fsm_number_of_programs_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fsm_programs_t fsm_programs;
   int32_t ret;
@@ -6413,7 +6413,7 @@ int32_t lsm6dsv16x_fsm_number_of_programs_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_start_address_set(stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_fsm_start_address_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -6433,7 +6433,7 @@ int32_t lsm6dsv16x_fsm_start_address_set(stmdev_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_fsm_start_address_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -6470,7 +6470,7 @@ int32_t lsm6dsv16x_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ff_time_windows_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_wake_up_dur_t wake_up_dur;
   lsm6dsv16x_free_fall_t free_fall;
@@ -6498,7 +6498,7 @@ int32_t lsm6dsv16x_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ff_time_windows_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ff_time_windows_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_wake_up_dur_t wake_up_dur;
   lsm6dsv16x_free_fall_t free_fall;
@@ -6520,7 +6520,7 @@ int32_t lsm6dsv16x_ff_time_windows_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ff_thresholds_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ff_thresholds_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t val)
 {
   lsm6dsv16x_free_fall_t free_fall;
@@ -6543,7 +6543,7 @@ int32_t lsm6dsv16x_ff_thresholds_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ff_thresholds_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t *val)
 {
   lsm6dsv16x_free_fall_t free_fall;
@@ -6616,7 +6616,7 @@ int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_set(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val)
+int32_t lsm6dsv16x_mlc_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val)
 {
   lsm6dsv16x_emb_func_en_b_t emb_en_b;
   lsm6dsv16x_emb_func_en_a_t emb_en_a;
@@ -6663,7 +6663,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val)
+int32_t lsm6dsv16x_mlc_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val)
 {
   lsm6dsv16x_emb_func_en_b_t emb_en_b;
   lsm6dsv16x_emb_func_en_a_t emb_en_a;
@@ -6700,7 +6700,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t val)
 {
   lsm6dsv16x_mlc_odr_t mlc_odr;
@@ -6729,7 +6729,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t *val)
 {
   lsm6dsv16x_mlc_odr_t mlc_odr;
@@ -6787,7 +6787,7 @@ int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val)
+int32_t lsm6dsv16x_mlc_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val)
 {
   int32_t ret;
 
@@ -6808,7 +6808,7 @@ int32_t lsm6dsv16x_mlc_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -6829,7 +6829,7 @@ int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(stmdev_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
                                                 uint16_t *val)
 {
   uint8_t buff[2];
@@ -6867,7 +6867,7 @@ int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_ctrl_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_ctrl_mode_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_ois_ctrl_mode_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
@@ -6890,7 +6890,7 @@ int32_t lsm6dsv16x_ois_ctrl_mode_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_ctrl_mode_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_ois_ctrl_mode_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
@@ -6926,7 +6926,7 @@ int32_t lsm6dsv16x_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_reset_set(stmdev_ctx_t *ctx, int8_t val)
+int32_t lsm6dsv16x_ois_reset_set(lsm6dsv16x_ctx_t *ctx, int8_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -6948,7 +6948,7 @@ int32_t lsm6dsv16x_ois_reset_set(stmdev_ctx_t *ctx, int8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_reset_get(stmdev_ctx_t *ctx, int8_t *val)
+int32_t lsm6dsv16x_ois_reset_get(lsm6dsv16x_ctx_t *ctx, int8_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -6967,7 +6967,7 @@ int32_t lsm6dsv16x_ois_reset_get(stmdev_ctx_t *ctx, int8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_interface_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ois_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
@@ -6989,7 +6989,7 @@ int32_t lsm6dsv16x_ois_interface_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_interface_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ois_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
@@ -7008,7 +7008,7 @@ int32_t lsm6dsv16x_ois_interface_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_handshake_from_ui_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ui_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_ois_handshake_t val)
 {
   lsm6dsv16x_ui_handshake_ctrl_t ui_handshake_ctrl;
@@ -7032,7 +7032,7 @@ int32_t lsm6dsv16x_ois_handshake_from_ui_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_handshake_from_ui_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ui_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_ois_handshake_t *val)
 {
   lsm6dsv16x_ui_handshake_ctrl_t ui_handshake_ctrl;
@@ -7057,7 +7057,7 @@ int32_t lsm6dsv16x_ois_handshake_from_ui_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_handshake_from_ois_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ois_set(lsm6dsv16x_ctx_t *ctx,
                                               lsm6dsv16x_ois_handshake_t val)
 {
   lsm6dsv16x_spi2_handshake_ctrl_t spi2_handshake_ctrl;
@@ -7081,7 +7081,7 @@ int32_t lsm6dsv16x_ois_handshake_from_ois_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_handshake_from_ois_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ois_get(lsm6dsv16x_ctx_t *ctx,
                                               lsm6dsv16x_ois_handshake_t *val)
 {
   lsm6dsv16x_spi2_handshake_ctrl_t spi2_handshake_ctrl;
@@ -7106,7 +7106,7 @@ int32_t lsm6dsv16x_ois_handshake_from_ois_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_shared_set(stmdev_ctx_t *ctx, uint8_t val[6])
+int32_t lsm6dsv16x_ois_shared_set(lsm6dsv16x_ctx_t *ctx, uint8_t val[6])
 {
   int32_t ret;
 
@@ -7123,7 +7123,7 @@ int32_t lsm6dsv16x_ois_shared_set(stmdev_ctx_t *ctx, uint8_t val[6])
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_shared_get(stmdev_ctx_t *ctx, uint8_t val[6])
+int32_t lsm6dsv16x_ois_shared_get(lsm6dsv16x_ctx_t *ctx, uint8_t val[6])
 {
   int32_t ret;
 
@@ -7140,7 +7140,7 @@ int32_t lsm6dsv16x_ois_shared_get(stmdev_ctx_t *ctx, uint8_t val[6])
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ois_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
@@ -7162,7 +7162,7 @@ int32_t lsm6dsv16x_ois_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ois_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
@@ -7181,7 +7181,7 @@ int32_t lsm6dsv16x_ois_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_chain_set(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t val)
+int32_t lsm6dsv16x_ois_chain_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_ois_chain_t val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
@@ -7204,7 +7204,7 @@ int32_t lsm6dsv16x_ois_chain_set(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_chain_get(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t *val)
+int32_t lsm6dsv16x_ois_chain_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_ois_chain_t *val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
@@ -7228,7 +7228,7 @@ int32_t lsm6dsv16x_ois_chain_get(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_gy_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t val)
 {
   lsm6dsv16x_ui_ctrl2_ois_t ui_ctrl2_ois;
@@ -7251,7 +7251,7 @@ int32_t lsm6dsv16x_ois_gy_full_scale_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t *val)
 {
   lsm6dsv16x_ui_ctrl2_ois_t ui_ctrl2_ois;
@@ -7299,7 +7299,7 @@ int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_xl_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t val)
 {
   lsm6dsv16x_ui_ctrl3_ois_t ui_ctrl3_ois;
@@ -7322,7 +7322,7 @@ int32_t lsm6dsv16x_ois_xl_full_scale_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t *val)
 {
   lsm6dsv16x_ui_ctrl3_ois_t ui_ctrl3_ois;
@@ -7379,7 +7379,7 @@ int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_6d_threshold_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_6d_threshold_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_6d_threshold_t val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
@@ -7402,7 +7402,7 @@ int32_t lsm6dsv16x_6d_threshold_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_6d_threshold_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_6d_threshold_t *val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
@@ -7446,7 +7446,7 @@ int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_4d_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -7468,7 +7468,7 @@ int32_t lsm6dsv16x_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_4d_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -7500,7 +7500,7 @@ int32_t lsm6dsv16x_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_zin_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_zin_set(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
@@ -7523,7 +7523,7 @@ int32_t lsm6dsv16x_ah_qvar_zin_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_zin_get(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t *val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
@@ -7567,7 +7567,7 @@ int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_mode_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
@@ -7590,7 +7590,7 @@ int32_t lsm6dsv16x_ah_qvar_mode_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_mode_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t *val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
@@ -7623,7 +7623,7 @@ int32_t lsm6dsv16x_ah_qvar_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_i3c_reset_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_reset_mode_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
@@ -7646,7 +7646,7 @@ int32_t lsm6dsv16x_i3c_reset_mode_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_reset_mode_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t *val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
@@ -7682,7 +7682,7 @@ int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_i3c_ibi_time_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_ibi_time_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_i3c_ibi_time_t val)
 {
   lsm6dsv16x_ctrl5_t ctrl5;
@@ -7705,7 +7705,7 @@ int32_t lsm6dsv16x_i3c_ibi_time_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_i3c_ibi_time_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_ibi_time_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_i3c_ibi_time_t *val)
 {
   lsm6dsv16x_ctrl5_t ctrl5;
@@ -7762,7 +7762,7 @@ int32_t lsm6dsv16x_i3c_ibi_time_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_master_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx,
                                                    uint8_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
@@ -7785,7 +7785,7 @@ int32_t lsm6dsv16x_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_master_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx,
                                                    uint8_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
@@ -7805,7 +7805,7 @@ int32_t lsm6dsv16x_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
+int32_t lsm6dsv16x_sh_read_data_raw_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val,
                                         uint8_t len)
 {
   int32_t ret;
@@ -7825,7 +7825,7 @@ int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_slave_connected_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_slave_connected_set(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_sh_slave_connected_t val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -7854,7 +7854,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_slave_connected_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_slave_connected_get(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_sh_slave_connected_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -7900,7 +7900,7 @@ int32_t lsm6dsv16x_sh_slave_connected_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sh_master_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -7928,7 +7928,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sh_master_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -7951,7 +7951,7 @@ int32_t lsm6dsv16x_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sh_pass_through_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -7979,7 +7979,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sh_pass_through_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -8002,7 +8002,7 @@ int32_t lsm6dsv16x_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_syncro_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_syncro_mode_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -8031,7 +8031,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_syncro_mode_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -8069,7 +8069,7 @@ int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_write_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_write_mode_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_sh_write_mode_t val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -8098,7 +8098,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_write_mode_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_sh_write_mode_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -8136,7 +8136,7 @@ int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sh_reset_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -8164,7 +8164,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sh_reset_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -8190,7 +8190,7 @@ int32_t lsm6dsv16x_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_cfg_write(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_cfg_write(lsm6dsv16x_ctx_t *ctx,
                                 lsm6dsv16x_sh_cfg_write_t *val)
 {
   lsm6dsv16x_slv0_add_t reg;
@@ -8231,7 +8231,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t val)
 {
   lsm6dsv16x_slv0_config_t slv0_config;
@@ -8260,7 +8260,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t *val)
 {
   lsm6dsv16x_slv0_config_t slv0_config;
@@ -8317,7 +8317,7 @@ int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+int32_t lsm6dsv16x_sh_slv_cfg_read(lsm6dsv16x_ctx_t *ctx, uint8_t idx,
                                    lsm6dsv16x_sh_cfg_read_t *val)
 {
   lsm6dsv16x_slv0_add_t slv_add;
@@ -8367,7 +8367,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_status_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_status_get(lsm6dsv16x_ctx_t *ctx,
                                  lsm6dsv16x_status_master_t *val)
 {
   int32_t ret;
@@ -8398,7 +8398,7 @@ int32_t lsm6dsv16x_sh_status_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ui_sdo_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
@@ -8420,7 +8420,7 @@ int32_t lsm6dsv16x_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_sdo_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ui_sdo_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
@@ -8439,7 +8439,7 @@ int32_t lsm6dsv16x_ui_sdo_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
@@ -8462,7 +8462,7 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
@@ -8498,7 +8498,7 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t val)
+int32_t lsm6dsv16x_spi_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
@@ -8520,7 +8520,7 @@ int32_t lsm6dsv16x_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val)
+int32_t lsm6dsv16x_spi_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
@@ -8555,7 +8555,7 @@ int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_sda_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ui_sda_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
@@ -8577,7 +8577,7 @@ int32_t lsm6dsv16x_ui_sda_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_sda_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ui_sda_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
@@ -8596,7 +8596,7 @@ int32_t lsm6dsv16x_ui_sda_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_spi2_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val)
+int32_t lsm6dsv16x_spi2_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
@@ -8618,7 +8618,7 @@ int32_t lsm6dsv16x_spi2_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *val)
+int32_t lsm6dsv16x_spi2_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
@@ -8667,7 +8667,7 @@ int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sigmot_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -8694,7 +8694,7 @@ int32_t lsm6dsv16x_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sigmot_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -8732,7 +8732,7 @@ int32_t lsm6dsv16x_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_stpcnt_mode_set(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_stpcnt_mode_t val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
@@ -8780,7 +8780,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_stpcnt_mode_get(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_stpcnt_mode_t *val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
@@ -8813,7 +8813,7 @@ int32_t lsm6dsv16x_stpcnt_mode_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_steps_get(stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_stpcnt_steps_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -8839,7 +8839,7 @@ int32_t lsm6dsv16x_stpcnt_steps_get(stmdev_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_rst_step_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_stpcnt_rst_step_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_src_t emb_func_src;
   int32_t ret;
@@ -8871,7 +8871,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_rst_step_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_stpcnt_rst_step_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_src_t emb_func_src;
   int32_t ret;
@@ -8897,7 +8897,7 @@ int32_t lsm6dsv16x_stpcnt_rst_step_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_debounce_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_stpcnt_debounce_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_pedo_deb_steps_conf_t pedo_deb_steps_conf;
   int32_t ret;
@@ -8919,7 +8919,7 @@ int32_t lsm6dsv16x_stpcnt_debounce_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_debounce_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_stpcnt_debounce_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_pedo_deb_steps_conf_t pedo_deb_steps_conf;
   int32_t ret;
@@ -8938,7 +8938,7 @@ int32_t lsm6dsv16x_stpcnt_debounce_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_period_set(stmdev_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_stpcnt_period_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -8958,7 +8958,7 @@ int32_t lsm6dsv16x_stpcnt_period_set(stmdev_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_stpcnt_period_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -8994,7 +8994,7 @@ int32_t lsm6dsv16x_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sflp_game_rotation_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -9027,7 +9027,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sflp_game_rotation_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -9053,7 +9053,7 @@ int32_t lsm6dsv16x_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t val)
 {
   lsm6dsv16x_sflp_odr_t sflp_odr;
@@ -9086,7 +9086,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t *val)
 {
   lsm6dsv16x_sflp_odr_t sflp_odr;
@@ -9153,7 +9153,7 @@ int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_detection_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_detection_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
@@ -9178,7 +9178,7 @@ int32_t lsm6dsv16x_tap_detection_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_detection_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_detection_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t *val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
@@ -9204,7 +9204,7 @@ int32_t lsm6dsv16x_tap_detection_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_thresholds_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_thresholds_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
@@ -9238,7 +9238,7 @@ int32_t lsm6dsv16x_tap_thresholds_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_thresholds_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_thresholds_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t *val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
@@ -9268,7 +9268,7 @@ int32_t lsm6dsv16x_tap_thresholds_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_axis_priority_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_axis_priority_set(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t val)
 {
   lsm6dsv16x_tap_cfg1_t tap_cfg1;
@@ -9291,7 +9291,7 @@ int32_t lsm6dsv16x_tap_axis_priority_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_axis_priority_get(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t *val)
 {
   lsm6dsv16x_tap_cfg1_t tap_cfg1;
@@ -9343,7 +9343,7 @@ int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_time_windows_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_time_windows_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t val)
 {
   lsm6dsv16x_tap_dur_t tap_dur;
@@ -9368,7 +9368,7 @@ int32_t lsm6dsv16x_tap_time_windows_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_time_windows_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_time_windows_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t *val)
 {
   lsm6dsv16x_tap_dur_t tap_dur;
@@ -9394,7 +9394,7 @@ int32_t lsm6dsv16x_tap_time_windows_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t val)
+int32_t lsm6dsv16x_tap_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t val)
 {
   lsm6dsv16x_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -9416,7 +9416,7 @@ int32_t lsm6dsv16x_tap_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val)
+int32_t lsm6dsv16x_tap_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val)
 {
   lsm6dsv16x_wake_up_ths_t wake_up_ths;
   int32_t ret;
@@ -9464,7 +9464,7 @@ int32_t lsm6dsv16x_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tilt_mode_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_tilt_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -9491,7 +9491,7 @@ int32_t lsm6dsv16x_tilt_mode_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tilt_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_tilt_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
@@ -9530,7 +9530,7 @@ int32_t lsm6dsv16x_tilt_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val)
+int32_t lsm6dsv16x_timestamp_raw_get(lsm6dsv16x_ctx_t *ctx, uint32_t *val)
 {
   uint8_t buff[4];
   int32_t ret;
@@ -9556,7 +9556,7 @@ int32_t lsm6dsv16x_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_timestamp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_functions_enable_t functions_enable;
   int32_t ret;
@@ -9578,7 +9578,7 @@ int32_t lsm6dsv16x_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_timestamp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_functions_enable_t functions_enable;
   int32_t ret;
@@ -9610,7 +9610,7 @@ int32_t lsm6dsv16x_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t val)
+int32_t lsm6dsv16x_act_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t val)
 {
   lsm6dsv16x_functions_enable_t functions_enable;
   int32_t ret;
@@ -9632,7 +9632,7 @@ int32_t lsm6dsv16x_act_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val)
+int32_t lsm6dsv16x_act_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t *val)
 {
   lsm6dsv16x_functions_enable_t functions_enable;
   int32_t ret;
@@ -9675,7 +9675,7 @@ int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(lsm6dsv16x_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
@@ -9698,7 +9698,7 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(lsm6dsv16x_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t *val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
@@ -9742,7 +9742,7 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_sleep_xl_odr_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_sleep_xl_odr_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
@@ -9765,7 +9765,7 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_sleep_xl_odr_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t *val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
@@ -9809,7 +9809,7 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_thresholds_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_thresholds_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val)
 {
   lsm6dsv16x_inactivity_ths_t inactivity_ths;
@@ -9850,7 +9850,7 @@ int32_t lsm6dsv16x_act_thresholds_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_thresholds_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_thresholds_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
@@ -9886,7 +9886,7 @@ int32_t lsm6dsv16x_act_thresholds_get(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_wkup_time_windows_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_wkup_time_windows_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_act_wkup_time_windows_t val)
 {
   lsm6dsv16x_wake_up_dur_t wake_up_dur;
@@ -9910,7 +9910,7 @@ int32_t lsm6dsv16x_act_wkup_time_windows_set(stmdev_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_wkup_time_windows_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_wkup_time_windows_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_act_wkup_time_windows_t *val)
 {
   lsm6dsv16x_wake_up_dur_t wake_up_dur;

--- a/src/lsm6dsv16x_reg.c
+++ b/src/lsm6dsv16x_reg.c
@@ -46,7 +46,7 @@
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak lsm6dsv16x_read_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
+int32_t __weak lsm6dsv16x_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
                                    uint8_t *data,
                                    uint16_t len)
 {
@@ -67,7 +67,7 @@ int32_t __weak lsm6dsv16x_read_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
   * @retval       interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t __weak lsm6dsv16x_write_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
+int32_t __weak lsm6dsv16x_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
                                     uint8_t *data,
                                     uint16_t len)
 {
@@ -92,7 +92,8 @@ int32_t __weak lsm6dsv16x_write_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
 
 static void bytecpy(uint8_t *target, uint8_t *source)
 {
-  if ((target != NULL) && (source != NULL)) {
+  if ((target != NULL) && (source != NULL))
+  {
     *target = *source;
   }
 }
@@ -173,6 +174,11 @@ float_t lsm6dsv16x_from_lsb_to_nsec(uint32_t lsb)
   return ((float_t)lsb * 21750.0f);
 }
 
+float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb)
+{
+  return ((float_t)lsb) / 78.0f;
+}
+
 /**
   * @}
   *
@@ -194,13 +200,14 @@ float_t lsm6dsv16x_from_lsb_to_nsec(uint32_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_offset_on_out_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_xl_offset_on_out_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl9.usr_off_on_out = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -216,7 +223,7 @@ int32_t lsm6dsv16x_xl_offset_on_out_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_offset_on_out_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_xl_offset_on_out_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -235,7 +242,7 @@ int32_t lsm6dsv16x_xl_offset_on_out_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_offset_mg_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t val)
 {
   lsm6dsv16x_z_ofs_usr_t z_ofs_usr;
@@ -248,14 +255,13 @@ int32_t lsm6dsv16x_xl_offset_mg_set(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
 
   if ((val.x_mg < (0.0078125f * 127.0f)) && (val.x_mg > (0.0078125f * -127.0f)) &&
       (val.y_mg < (0.0078125f * 127.0f)) && (val.y_mg > (0.0078125f * -127.0f)) &&
-      (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f))) {
+      (val.z_mg < (0.0078125f * 127.0f)) && (val.z_mg > (0.0078125f * -127.0f)))
+  {
     ctrl9.usr_off_w = 0;
 
     tmp = val.z_mg / 0.0078125f;
@@ -266,9 +272,11 @@ int32_t lsm6dsv16x_xl_offset_mg_set(lsm6dsv16x_ctx_t *ctx,
 
     tmp = val.x_mg / 0.0078125f;
     x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
-  } else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
-             (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
-             (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f))) {
+  }
+  else if ((val.x_mg < (0.125f * 127.0f)) && (val.x_mg > (0.125f * -127.0f)) &&
+           (val.y_mg < (0.125f * 127.0f)) && (val.y_mg > (0.125f * -127.0f)) &&
+           (val.z_mg < (0.125f * 127.0f)) && (val.z_mg > (0.125f * -127.0f)))
+  {
     ctrl9.usr_off_w = 1;
 
     tmp = val.z_mg / 0.125f;
@@ -279,7 +287,9 @@ int32_t lsm6dsv16x_xl_offset_mg_set(lsm6dsv16x_ctx_t *ctx,
 
     tmp = val.x_mg / 0.125f;
     x_ofs_usr.x_ofs_usr = (uint8_t)tmp;
-  } else { // out of limit
+  }
+  else // out of limit
+  {
     ctrl9.usr_off_w = 1;
     z_ofs_usr.z_ofs_usr = 0xFFU;
     y_ofs_usr.y_ofs_usr = 0xFFU;
@@ -302,7 +312,7 @@ int32_t lsm6dsv16x_xl_offset_mg_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_offset_mg_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_offset_mg_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t *val)
 {
   lsm6dsv16x_z_ofs_usr_t z_ofs_usr;
@@ -315,15 +325,16 @@ int32_t lsm6dsv16x_xl_offset_mg_get(lsm6dsv16x_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Z_OFS_USR, (uint8_t *)&z_ofs_usr, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_Y_OFS_USR, (uint8_t *)&y_ofs_usr, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_X_OFS_USR, (uint8_t *)&x_ofs_usr, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  if (ctrl9.usr_off_w == PROPERTY_DISABLE) {
+  if (ctrl9.usr_off_w == PROPERTY_DISABLE)
+  {
     val->z_mg = ((float_t)z_ofs_usr.z_ofs_usr * 0.0078125f);
     val->y_mg = ((float_t)y_ofs_usr.y_ofs_usr * 0.0078125f);
     val->x_mg = ((float_t)x_ofs_usr.x_ofs_usr * 0.0078125f);
-  } else {
+  }
+  else
+  {
     val->z_mg = ((float_t)z_ofs_usr.z_ofs_usr * 0.125f);
     val->y_mg = ((float_t)y_ofs_usr.y_ofs_usr * 0.125f);
     val->x_mg = ((float_t)x_ofs_usr.x_ofs_usr * 0.125f);
@@ -345,7 +356,7 @@ int32_t lsm6dsv16x_xl_offset_mg_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_reset_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t val)
+int32_t lsm6dsv16x_reset_set(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   lsm6dsv16x_ctrl3_t ctrl3;
@@ -353,9 +364,7 @@ int32_t lsm6dsv16x_reset_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ctrl3.boot = ((uint8_t)val & 0x04U) >> 2;
   ctrl3.sw_reset = ((uint8_t)val & 0x02U) >> 1;
@@ -375,7 +384,7 @@ int32_t lsm6dsv16x_reset_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_reset_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t *val)
+int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   lsm6dsv16x_ctrl3_t ctrl3;
@@ -383,11 +392,10 @@ int32_t lsm6dsv16x_reset_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t *val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch ((ctrl3.sw_reset << 2) + (ctrl3.boot << 1) + func_cfg_access.sw_por) {
+  switch ((ctrl3.sw_reset << 2) + (ctrl3.boot << 1) + func_cfg_access.sw_por)
+  {
     case LSM6DSV16X_READY:
       *val = LSM6DSV16X_READY;
       break;
@@ -420,15 +428,13 @@ int32_t lsm6dsv16x_reset_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mem_bank_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t val)
+int32_t lsm6dsv16x_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   func_cfg_access.shub_reg_access = ((uint8_t)val & 0x02U) >> 1;
   func_cfg_access.emb_func_reg_access = (uint8_t)val & 0x01U;
@@ -445,17 +451,16 @@ int32_t lsm6dsv16x_mem_bank_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mem_bank_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val)
+int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch ((func_cfg_access.shub_reg_access << 1) + func_cfg_access.emb_func_reg_access) {
+  switch ((func_cfg_access.shub_reg_access << 1) + func_cfg_access.emb_func_reg_access)
+  {
     case LSM6DSV16X_MAIN_MEM_BANK:
       *val = LSM6DSV16X_MAIN_MEM_BANK;
       break;
@@ -485,7 +490,7 @@ int32_t lsm6dsv16x_mem_bank_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_device_id_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_device_id_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
@@ -502,7 +507,7 @@ int32_t lsm6dsv16x_device_id_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_data_rate_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t val)
 {
   lsm6dsv16x_ctrl1_t ctrl1;
@@ -511,18 +516,15 @@ int32_t lsm6dsv16x_xl_data_rate_set(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ctrl1.odr_xl = (uint8_t)val & 0x0Fu;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   sel = ((uint8_t)val >> 4) & 0xFU;
-  if (sel != 0U) {
+  if (sel != 0U)
+  {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
     haodr.haodr_sel = sel;
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
@@ -539,7 +541,7 @@ int32_t lsm6dsv16x_xl_data_rate_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val)
 {
   lsm6dsv16x_ctrl1_t ctrl1;
@@ -549,13 +551,12 @@ int32_t lsm6dsv16x_xl_data_rate_get(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   sel = haodr.haodr_sel;
 
-  switch (ctrl1.odr_xl) {
+  switch (ctrl1.odr_xl)
+  {
     case LSM6DSV16X_ODR_OFF:
       *val = LSM6DSV16X_ODR_OFF;
       break;
@@ -570,151 +571,151 @@ int32_t lsm6dsv16x_xl_data_rate_get(lsm6dsv16x_ctx_t *ctx,
 
     case LSM6DSV16X_ODR_AT_15Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_15Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_15Hz625;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_12Hz5;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_15Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_15Hz625;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_12Hz5;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_30Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_30Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_31Hz25;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_25Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_30Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_31Hz25;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_25Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_60Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_60Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_62Hz5;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_50Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_60Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_62Hz5;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_50Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_120Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_120Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_125Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_100Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_120Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_125Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_100Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_240Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_240Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_250Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_200Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_240Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_250Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_200Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_480Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_480Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_500Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_400Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_480Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_500Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_400Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_960Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_960Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_1000Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_800Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_960Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_1000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_800Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_1920Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_1920Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_2000Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_1600Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_1920Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_2000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_1600Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_3840Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_3840Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_4000Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_3200Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_3840Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_4000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_3200Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_7680Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_7680Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_8000Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_6400Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_7680Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_8000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_6400Hz;
+        break;
       }
       break;
 
@@ -734,14 +735,15 @@ int32_t lsm6dsv16x_xl_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t val)
+int32_t lsm6dsv16x_xl_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t val)
 {
   lsm6dsv16x_ctrl1_t ctrl1;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl1.op_mode_xl = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
   }
@@ -757,17 +759,16 @@ int32_t lsm6dsv16x_xl_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
+int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
 {
   lsm6dsv16x_ctrl1_t ctrl1;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, (uint8_t *)&ctrl1, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl1.op_mode_xl) {
+  switch (ctrl1.op_mode_xl)
+  {
     case LSM6DSV16X_XL_HIGH_PERFORMANCE_MD:
       *val = LSM6DSV16X_XL_HIGH_PERFORMANCE_MD;
       break;
@@ -812,7 +813,7 @@ int32_t lsm6dsv16x_xl_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_data_rate_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t val)
 {
   lsm6dsv16x_ctrl2_t ctrl2;
@@ -823,12 +824,11 @@ int32_t lsm6dsv16x_gy_data_rate_set(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
   ctrl2.odr_g = (uint8_t)val & 0x0Fu;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   sel = ((uint8_t)val >> 4) & 0xFU;
-  if (sel != 0U) {
+  if (sel != 0U)
+  {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
     haodr.haodr_sel = sel;
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
@@ -845,7 +845,7 @@ int32_t lsm6dsv16x_gy_data_rate_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val)
 {
   lsm6dsv16x_ctrl2_t ctrl2;
@@ -855,13 +855,12 @@ int32_t lsm6dsv16x_gy_data_rate_get(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_HAODR_CFG, (uint8_t *)&haodr, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   sel = haodr.haodr_sel;
 
-  switch (ctrl2.odr_g) {
+  switch (ctrl2.odr_g)
+  {
     case LSM6DSV16X_ODR_OFF:
       *val = LSM6DSV16X_ODR_OFF;
       break;
@@ -876,151 +875,151 @@ int32_t lsm6dsv16x_gy_data_rate_get(lsm6dsv16x_ctx_t *ctx,
 
     case LSM6DSV16X_ODR_AT_15Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_15Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_15Hz625;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_12Hz5;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_15Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_15Hz625;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_12Hz5;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_30Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_30Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_31Hz25;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_25Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_30Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_31Hz25;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_25Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_60Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_60Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_62Hz5;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_50Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_60Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_62Hz5;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_50Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_120Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_120Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_125Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_100Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_120Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_125Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_100Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_240Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_240Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_250Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_200Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_240Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_250Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_200Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_480Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_480Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_500Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_400Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_480Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_500Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_400Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_960Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_960Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_1000Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_800Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_960Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_1000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_800Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_1920Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_1920Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_2000Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_1600Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_1920Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_2000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_1600Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_3840Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_3840Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_4000Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_3200Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_3840Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_4000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_3200Hz;
+        break;
       }
       break;
 
     case LSM6DSV16X_ODR_AT_7680Hz:
       switch (sel) {
-        default:
-        case 0:
-          *val = LSM6DSV16X_ODR_AT_7680Hz;
-          break;
-        case 1:
-          *val = LSM6DSV16X_ODR_HA01_AT_8000Hz;
-          break;
-        case 2:
-          *val = LSM6DSV16X_ODR_HA02_AT_6400Hz;
-          break;
+      default:
+      case 0:
+        *val = LSM6DSV16X_ODR_AT_7680Hz;
+        break;
+      case 1:
+        *val = LSM6DSV16X_ODR_HA01_AT_8000Hz;
+        break;
+      case 2:
+        *val = LSM6DSV16X_ODR_HA02_AT_6400Hz;
+        break;
       }
       break;
 
@@ -1040,13 +1039,14 @@ int32_t lsm6dsv16x_gy_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t val)
+int32_t lsm6dsv16x_gy_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t val)
 {
   lsm6dsv16x_ctrl2_t ctrl2;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl2.op_mode_g = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
   }
@@ -1062,17 +1062,16 @@ int32_t lsm6dsv16x_gy_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
+int32_t lsm6dsv16x_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
 {
   lsm6dsv16x_ctrl2_t ctrl2;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL2, (uint8_t *)&ctrl2, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl2.op_mode_g) {
+  switch (ctrl2.op_mode_g)
+  {
     case LSM6DSV16X_GY_HIGH_PERFORMANCE_MD:
       *val = LSM6DSV16X_GY_HIGH_PERFORMANCE_MD;
       break;
@@ -1105,13 +1104,14 @@ int32_t lsm6dsv16x_gy_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_auto_increment_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl3_t ctrl3;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl3.if_inc = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
@@ -1127,7 +1127,7 @@ int32_t lsm6dsv16x_auto_increment_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_auto_increment_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl3_t ctrl3;
   int32_t ret;
@@ -1146,14 +1146,15 @@ int32_t lsm6dsv16x_auto_increment_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_block_data_update_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl3_t ctrl3;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl3.bdu = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL3, (uint8_t *)&ctrl3, 1);
   }
@@ -1169,7 +1170,7 @@ int32_t lsm6dsv16x_block_data_update_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_block_data_update_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl3_t ctrl3;
   int32_t ret;
@@ -1188,7 +1189,7 @@ int32_t lsm6dsv16x_block_data_update_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_odr_trig_cfg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_odr_trig_cfg_t odr_trig;
   int32_t ret;
@@ -1199,7 +1200,8 @@ int32_t lsm6dsv16x_odr_trig_cfg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     odr_trig.odr_trig_nodr = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_ODR_TRIG_CFG, (uint8_t *)&odr_trig, 1);
   }
@@ -1215,7 +1217,7 @@ int32_t lsm6dsv16x_odr_trig_cfg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_odr_trig_cfg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_odr_trig_cfg_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_odr_trig_cfg_t odr_trig;
   int32_t ret;
@@ -1234,7 +1236,7 @@ int32_t lsm6dsv16x_odr_trig_cfg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_data_ready_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_data_ready_mode_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t val)
 {
   lsm6dsv16x_ctrl4_t ctrl4;
@@ -1242,7 +1244,8 @@ int32_t lsm6dsv16x_data_ready_mode_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl4.drdy_pulsed = (uint8_t)val & 0x1U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
   }
@@ -1258,7 +1261,7 @@ int32_t lsm6dsv16x_data_ready_mode_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_data_ready_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_data_ready_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t *val)
 {
   lsm6dsv16x_ctrl4_t ctrl4;
@@ -1266,7 +1269,8 @@ int32_t lsm6dsv16x_data_ready_mode_get(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
 
-  switch (ctrl4.drdy_pulsed) {
+  switch (ctrl4.drdy_pulsed)
+  {
     case LSM6DSV16X_DRDY_LATCHED:
       *val = LSM6DSV16X_DRDY_LATCHED;
       break;
@@ -1291,7 +1295,7 @@ int32_t lsm6dsv16x_data_ready_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_interrupt_enable_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_interrupt_enable_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t val)
 {
   lsm6dsv16x_tap_cfg0_t cfg;
@@ -1301,9 +1305,7 @@ int32_t lsm6dsv16x_interrupt_enable_set(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
   func.interrupts_enable = val.enable;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
   cfg.lir = val.lir;
@@ -1320,7 +1322,7 @@ int32_t lsm6dsv16x_interrupt_enable_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_interrupt_enable_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_interrupt_enable_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t *val)
 {
   lsm6dsv16x_tap_cfg0_t cfg;
@@ -1329,9 +1331,7 @@ int32_t lsm6dsv16x_interrupt_enable_get(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&func, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->enable = func.interrupts_enable;
   val->lir = cfg.lir;
@@ -1347,7 +1347,7 @@ int32_t lsm6dsv16x_interrupt_enable_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_full_scale_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t val)
 {
   lsm6dsv16x_ctrl6_t ctrl6;
@@ -1355,7 +1355,8 @@ int32_t lsm6dsv16x_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl6.fs_g = (uint8_t)val & 0xfu;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
   }
@@ -1371,18 +1372,17 @@ int32_t lsm6dsv16x_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t *val)
 {
   lsm6dsv16x_ctrl6_t ctrl6;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl6.fs_g) {
+  switch (ctrl6.fs_g)
+  {
     case LSM6DSV16X_125dps:
       *val = LSM6DSV16X_125dps;
       break;
@@ -1423,7 +1423,7 @@ int32_t lsm6dsv16x_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_full_scale_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_xl_full_scale_t val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
@@ -1431,7 +1431,8 @@ int32_t lsm6dsv16x_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl8.fs_xl = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
   }
@@ -1447,18 +1448,17 @@ int32_t lsm6dsv16x_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_xl_full_scale_t *val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl8.fs_xl) {
+  switch (ctrl8.fs_xl)
+  {
     case LSM6DSV16X_2g:
       *val = LSM6DSV16X_2g;
       break;
@@ -1491,14 +1491,15 @@ int32_t lsm6dsv16x_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_dual_channel_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_xl_dual_channel_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl8.xl_dualc_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
   }
@@ -1514,7 +1515,7 @@ int32_t lsm6dsv16x_xl_dual_channel_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_dual_channel_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_xl_dual_channel_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
   int32_t ret;
@@ -1533,7 +1534,7 @@ int32_t lsm6dsv16x_xl_dual_channel_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_self_test_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
@@ -1541,7 +1542,8 @@ int32_t lsm6dsv16x_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl10.st_xl = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
@@ -1557,18 +1559,17 @@ int32_t lsm6dsv16x_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t *val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl10.st_xl) {
+  switch (ctrl10.st_xl)
+  {
     case LSM6DSV16X_XL_ST_DISABLE:
       *val = LSM6DSV16X_XL_ST_DISABLE;
       break;
@@ -1597,7 +1598,7 @@ int32_t lsm6dsv16x_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_self_test_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
@@ -1605,7 +1606,8 @@ int32_t lsm6dsv16x_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl10.st_g = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
@@ -1621,18 +1623,17 @@ int32_t lsm6dsv16x_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t *val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl10.st_g) {
+  switch (ctrl10.st_g)
+  {
     case LSM6DSV16X_GY_ST_DISABLE:
       *val = LSM6DSV16X_GY_ST_DISABLE;
       break;
@@ -1661,7 +1662,7 @@ int32_t lsm6dsv16x_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_self_test_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
@@ -1669,7 +1670,8 @@ int32_t lsm6dsv16x_ois_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     spi2_int_ois.st_xl_ois = ((uint8_t)val & 0x3U);
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
   }
@@ -1685,18 +1687,17 @@ int32_t lsm6dsv16x_ois_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t *val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (spi2_int_ois.st_xl_ois) {
+  switch (spi2_int_ois.st_xl_ois)
+  {
     case LSM6DSV16X_OIS_XL_ST_DISABLE:
       *val = LSM6DSV16X_OIS_XL_ST_DISABLE;
       break;
@@ -1725,7 +1726,7 @@ int32_t lsm6dsv16x_ois_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_self_test_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
@@ -1733,7 +1734,8 @@ int32_t lsm6dsv16x_ois_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     spi2_int_ois.st_g_ois = ((uint8_t)val & 0x3U);
     spi2_int_ois.st_ois_clampdis = ((uint8_t)val & 0x04U) >> 2;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
@@ -1750,18 +1752,17 @@ int32_t lsm6dsv16x_ois_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t *val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (spi2_int_ois.st_g_ois) {
+  switch (spi2_int_ois.st_g_ois)
+  {
     case LSM6DSV16X_OIS_GY_ST_DISABLE:
       *val = LSM6DSV16X_OIS_GY_ST_DISABLE;
       break;
@@ -1798,7 +1799,7 @@ int32_t lsm6dsv16x_ois_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsv16x_pin_int1_route_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val)
 {
   lsm6dsv16x_int1_ctrl_t          int1_ctrl;
@@ -1806,9 +1807,7 @@ int32_t lsm6dsv16x_pin_int1_route_set(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   int1_ctrl.int1_drdy_xl       = val->drdy_xl;
   int1_ctrl.int1_drdy_g        = val->drdy_g;
@@ -1818,14 +1817,10 @@ int32_t lsm6dsv16x_pin_int1_route_set(lsm6dsv16x_ctx_t *ctx,
   int1_ctrl.int1_cnt_bdr       = val->cnt_bdr;
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   md1_cfg.int1_shub            = val->shub;
   md1_cfg.int1_emb_func        = val->emb_func;
@@ -1849,7 +1844,7 @@ int32_t lsm6dsv16x_pin_int1_route_set(lsm6dsv16x_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsv16x_pin_int1_route_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val)
 {
   lsm6dsv16x_int1_ctrl_t          int1_ctrl;
@@ -1857,9 +1852,7 @@ int32_t lsm6dsv16x_pin_int1_route_get(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT1_CTRL, (uint8_t *)&int1_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->drdy_xl   = int1_ctrl.int1_drdy_xl;
   val->drdy_g    = int1_ctrl.int1_drdy_g;
@@ -1869,9 +1862,7 @@ int32_t lsm6dsv16x_pin_int1_route_get(lsm6dsv16x_ctx_t *ctx,
   val->cnt_bdr   = int1_ctrl.int1_cnt_bdr;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD1_CFG, (uint8_t *)&md1_cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->shub         = md1_cfg.int1_shub;
   val->emb_func     = md1_cfg.int1_emb_func;
@@ -1893,7 +1884,7 @@ int32_t lsm6dsv16x_pin_int1_route_get(lsm6dsv16x_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsv16x_pin_int2_route_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val)
 {
   lsm6dsv16x_int2_ctrl_t          int2_ctrl;
@@ -1901,9 +1892,7 @@ int32_t lsm6dsv16x_pin_int2_route_set(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   int2_ctrl.int2_drdy_xl          = val->drdy_xl;
   int2_ctrl.int2_drdy_g           = val->drdy_g;
@@ -1915,14 +1904,10 @@ int32_t lsm6dsv16x_pin_int2_route_set(lsm6dsv16x_ctx_t *ctx,
   int2_ctrl.int2_emb_func_endop   = val->emb_func_endop;
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   md2_cfg.int2_timestamp       = val->timestamp;
   md2_cfg.int2_emb_func        = val->emb_func;
@@ -1946,7 +1931,7 @@ int32_t lsm6dsv16x_pin_int2_route_set(lsm6dsv16x_ctx_t *ctx,
   * @retval        Interface status (MANDATORY: return 0 -> no Error).
   *
   */
-int32_t lsm6dsv16x_pin_int2_route_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val)
 {
   lsm6dsv16x_int2_ctrl_t          int2_ctrl;
@@ -1954,9 +1939,7 @@ int32_t lsm6dsv16x_pin_int2_route_get(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->drdy_xl        = int2_ctrl.int2_drdy_xl;
   val->drdy_g         = int2_ctrl.int2_drdy_g;
@@ -1968,9 +1951,7 @@ int32_t lsm6dsv16x_pin_int2_route_get(lsm6dsv16x_ctx_t *ctx,
   val->emb_func_endop = int2_ctrl.int2_emb_func_endop;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MD2_CFG, (uint8_t *)&md2_cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->timestamp      = md2_cfg.int2_timestamp;
   val->emb_func       = md2_cfg.int2_emb_func;
@@ -1997,7 +1978,7 @@ int32_t lsm6dsv16x_pin_int2_route_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_all_sources_t *val)
 {
   lsm6dsv16x_emb_func_status_mainpage_t emb_func_status_mainpage;
@@ -2020,14 +2001,10 @@ int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   functions_enable.dis_rst_lir_all_int = PROPERTY_ENABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_STATUS1, (uint8_t *)&buff, 4);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   bytecpy((uint8_t *)&fifo_status2, &buff[1]);
   bytecpy((uint8_t *)&all_int_src, &buff[2]);
@@ -2053,14 +2030,10 @@ int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   functions_enable.dis_rst_lir_all_int = PROPERTY_DISABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_STATUS_REG_OIS, (uint8_t *)&buff, 8);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   bytecpy((uint8_t *)&status_reg_ois, &buff[0]);
   bytecpy((uint8_t *)&wake_up_src, &buff[1]);
@@ -2116,9 +2089,7 @@ int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EXEC_STATUS, (uint8_t *)&emb_func_exec_status, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->emb_func_stand_by = emb_func_exec_status.emb_func_endop;
   val->emb_func_time_exceed = emb_func_exec_status.emb_func_exec_ovr;
@@ -2130,9 +2101,7 @@ int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
 
   /* sensor hub */
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STATUS_MASTER_MAINPAGE, (uint8_t *)&status_shub, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->sh_endop = status_shub.sens_hub_endop;
   val->sh_wr_once = status_shub.wr_once_done;
@@ -2144,16 +2113,14 @@ int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
   return ret;
 }
 
-int32_t lsm6dsv16x_flag_data_ready_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_flag_data_ready_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_t *val)
 {
   lsm6dsv16x_status_reg_t status;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STATUS_REG, (uint8_t *)&status, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->drdy_xl = status.xlda;
   val->drdy_gy = status.gda;
@@ -2170,7 +2137,7 @@ int32_t lsm6dsv16x_flag_data_ready_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_int_ack_mask_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_int_ack_mask_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   int32_t ret;
 
@@ -2187,7 +2154,7 @@ int32_t lsm6dsv16x_int_ack_mask_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_int_ack_mask_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_int_ack_mask_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   int32_t ret;
 
@@ -2204,15 +2171,13 @@ int32_t lsm6dsv16x_int_ack_mask_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_temperature_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUT_TEMP_L, &buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
@@ -2228,15 +2193,13 @@ int32_t lsm6dsv16x_temperature_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUTX_L_G, &buff[0], 6);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -2256,15 +2219,13 @@ int32_t lsm6dsv16x_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_OUTX_L_G_OIS, &buff[0], 6);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val[0] = (int16_t)buff[1];
   val[0] = (*val * 256) + (int16_t)buff[0];
@@ -2284,15 +2245,13 @@ int32_t lsm6dsv16x_ois_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_OUTX_L_G_OIS_EIS, &buff[0], 6);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val[0] = (int16_t)buff[1];
   val[0] = (*val * 256) + (int16_t)buff[0];
@@ -2312,15 +2271,13 @@ int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_OUTX_L_A, &buff[0], 6);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -2340,15 +2297,13 @@ int32_t lsm6dsv16x_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_dual_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_dual_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_OUTX_L_A_OIS_DUALC, &buff[0], 6);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val[0] = (int16_t)buff[1];
   val[0] = (val[0] * 256) + (int16_t)buff[0];
@@ -2368,15 +2323,13 @@ int32_t lsm6dsv16x_dual_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
+int32_t lsm6dsv16x_ah_qvar_raw_get(stmdev_ctx_t *ctx, int16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_AH_QVAR_OUT_L, &buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = (int16_t)buff[1];
   *val = (*val * 256) + (int16_t)buff[0];
@@ -2392,7 +2345,7 @@ int32_t lsm6dsv16x_ah_qvar_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_odr_cal_reg_get(lsm6dsv16x_ctx_t *ctx, int8_t *val)
+int32_t lsm6dsv16x_odr_cal_reg_get(stmdev_ctx_t *ctx, int8_t *val)
 {
   lsm6dsv16x_internal_freq_t internal_freq;
   int32_t ret;
@@ -2411,7 +2364,7 @@ int32_t lsm6dsv16x_odr_cal_reg_get(lsm6dsv16x_ctx_t *ctx, int8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ln_pg_write(lsm6dsv16x_ctx_t *ctx, uint16_t address,
+int32_t lsm6dsv16x_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
                                uint8_t *buf, uint8_t len)
 {
   lsm6dsv16x_page_address_t  page_address;
@@ -2426,67 +2379,53 @@ int32_t lsm6dsv16x_ln_pg_write(lsm6dsv16x_ctx_t *ctx, uint16_t address,
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   /* set page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_DISABLE;
   page_rw.page_write = PROPERTY_ENABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   /* select page */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   /* set page addr */
   page_address.page_addr = lsb;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_ADDRESS,
                               (uint8_t *)&page_address, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
-  for (i = 0; ((i < len) && (ret == 0)); i++) {
+  for (i = 0; ((i < len) && (ret == 0)); i++)
+  {
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_VALUE, &buf[i], 1);
-    if (ret != 0) {
-      goto exit;
-    }
+    if (ret != 0) { goto exit; }
 
     lsb++;
 
     /* Check if page wrap */
-    if (((lsb & 0xFFU) == 0x00U) && (ret == 0)) {
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
       msb++;
       ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      if (ret != 0) {
-        goto exit;
-      }
+      if (ret != 0) { goto exit; }
 
       page_sel.page_sel = msb;
       page_sel.not_used0 = 1; // Default value
       ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      if (ret != 0) {
-        goto exit;
-      }
+      if (ret != 0) { goto exit; }
     }
   }
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   /* unset page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
@@ -2515,7 +2454,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ln_pg_read(lsm6dsv16x_ctx_t *ctx, uint16_t address, uint8_t *buf,
+int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
                               uint8_t len)
 {
   lsm6dsv16x_page_address_t  page_address;
@@ -2530,67 +2469,53 @@ int32_t lsm6dsv16x_ln_pg_read(lsm6dsv16x_ctx_t *ctx, uint16_t address, uint8_t *
   lsb = (uint8_t)address & 0xFFU;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   /* set page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
   page_rw.page_read = PROPERTY_ENABLE;
   page_rw.page_write = PROPERTY_DISABLE;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   /* select page */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
   page_sel.page_sel = msb;
   page_sel.not_used0 = 1; // Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   /* set page addr */
   page_address.page_addr = lsb;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_ADDRESS,
                               (uint8_t *)&page_address, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
-  for (i = 0; ((i < len) && (ret == 0)); i++) {
+  for (i = 0; ((i < len) && (ret == 0)); i++)
+  {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_VALUE, &buf[i], 1);
-    if (ret != 0) {
-      goto exit;
-    }
+    if (ret != 0) { goto exit; }
 
     lsb++;
 
     /* Check if page wrap */
-    if (((lsb & 0xFFU) == 0x00U) && (ret == 0)) {
+    if (((lsb & 0xFFU) == 0x00U) && (ret == 0))
+    {
       msb++;
       ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      if (ret != 0) {
-        goto exit;
-      }
+      if (ret != 0) { goto exit; }
 
       page_sel.page_sel = msb;
       page_sel.not_used0 = 1; // Default value
       ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-      if (ret != 0) {
-        goto exit;
-      }
+      if (ret != 0) { goto exit; }
     }
   }
 
   page_sel.page_sel = 0;
   page_sel.not_used0 = 1;// Default value
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PAGE_SEL, (uint8_t *)&page_sel, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   /* unset page write */
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PAGE_RW, (uint8_t *)&page_rw, 1);
@@ -2612,14 +2537,15 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_emb_function_dbg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_emb_function_dbg_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl10.emb_func_debug = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
   }
@@ -2635,15 +2561,13 @@ int32_t lsm6dsv16x_emb_function_dbg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_emb_function_dbg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl10_t ctrl10;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL10, (uint8_t *)&ctrl10, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = ctrl10.emb_func_debug;
 
@@ -2671,7 +2595,7 @@ int32_t lsm6dsv16x_emb_function_dbg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_den_polarity_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_den_polarity_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t val)
 {
   lsm6dsv16x_ctrl4_t ctrl4;
@@ -2679,7 +2603,8 @@ int32_t lsm6dsv16x_den_polarity_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl4.int2_in_lh = (uint8_t)val & 0x1U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
   }
@@ -2695,18 +2620,17 @@ int32_t lsm6dsv16x_den_polarity_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_den_polarity_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t *val)
 {
   lsm6dsv16x_ctrl4_t ctrl4;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl4.int2_in_lh) {
+  switch (ctrl4.int2_in_lh)
+  {
     case LSM6DSV16X_DEN_ACT_LOW:
       *val = LSM6DSV16X_DEN_ACT_LOW;
       break;
@@ -2731,15 +2655,13 @@ int32_t lsm6dsv16x_den_polarity_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_den_conf_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t val)
+int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val)
 {
   lsm6dsv16x_den_t den;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_DEN, (uint8_t *)&den, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   den.den_z = val.den_z;
   den.den_y = val.den_y;
@@ -2748,16 +2670,23 @@ int32_t lsm6dsv16x_den_conf_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t val
   den.lvl2_en = (uint8_t)val.mode & 0x1U;
   den.lvl1_en = ((uint8_t)val.mode & 0x2U) >> 1;
 
-  if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_ENABLE) {
+  if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
+  {
     den.den_xl_g = PROPERTY_DISABLE;
     den.den_xl_en = PROPERTY_ENABLE;
-  } else if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_DISABLE) {
+  }
+  else if (val.stamp_in_gy_data == PROPERTY_ENABLE && val.stamp_in_xl_data == PROPERTY_DISABLE)
+  {
     den.den_xl_g = PROPERTY_DISABLE;
     den.den_xl_en = PROPERTY_DISABLE;
-  } else if (val.stamp_in_gy_data == PROPERTY_DISABLE && val.stamp_in_xl_data == PROPERTY_ENABLE) {
+  }
+  else if (val.stamp_in_gy_data == PROPERTY_DISABLE && val.stamp_in_xl_data == PROPERTY_ENABLE)
+  {
     den.den_xl_g = PROPERTY_ENABLE;
     den.den_xl_en = PROPERTY_DISABLE;
-  } else {
+  }
+  else
+  {
     den.den_xl_g = PROPERTY_DISABLE;
     den.den_xl_en = PROPERTY_DISABLE;
     den.den_z = PROPERTY_DISABLE;
@@ -2781,37 +2710,44 @@ int32_t lsm6dsv16x_den_conf_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_den_conf_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t *val)
+int32_t lsm6dsv16x_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t *val)
 {
   lsm6dsv16x_den_t den;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_DEN, (uint8_t *)&den, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->den_z = den.den_z;
   val->den_y = den.den_y;
   val->den_x = den.den_x;
 
-  if ((den.den_z | den.den_z | den.den_z) == PROPERTY_ENABLE) {
-    if (den.den_xl_g == PROPERTY_DISABLE && den.den_xl_en == PROPERTY_ENABLE) {
+  if ((den.den_x | den.den_y | den.den_z) == PROPERTY_ENABLE)
+  {
+    if (den.den_xl_g == PROPERTY_DISABLE && den.den_xl_en == PROPERTY_ENABLE)
+    {
       val->stamp_in_gy_data = PROPERTY_ENABLE;
       val->stamp_in_xl_data = PROPERTY_ENABLE;
-    } else if (den.den_xl_g == PROPERTY_DISABLE && den.den_xl_en == PROPERTY_DISABLE) {
+    }
+    else if (den.den_xl_g == PROPERTY_DISABLE && den.den_xl_en == PROPERTY_DISABLE)
+    {
       val->stamp_in_gy_data = PROPERTY_ENABLE;
       val->stamp_in_xl_data = PROPERTY_DISABLE;
-    } else { // ( (den.den_xl_g & !den.den_xl_en) == PROPERTY_ENABLE )
+    }
+    else // ( (den.den_xl_g & !den.den_xl_en) == PROPERTY_ENABLE )
+    {
       val->stamp_in_gy_data = PROPERTY_DISABLE;
       val->stamp_in_xl_data = PROPERTY_ENABLE;
     }
-  } else {
+  }
+  else
+  {
     val->stamp_in_gy_data = PROPERTY_DISABLE;
     val->stamp_in_xl_data = PROPERTY_DISABLE;
   }
 
-  switch ((den.lvl1_en << 1) + den.lvl2_en) {
+  switch ((den.lvl1_en << 1) + den.lvl2_en)
+  {
     case LEVEL_TRIGGER:
       val->mode = LEVEL_TRIGGER;
       break;
@@ -2848,7 +2784,7 @@ int32_t lsm6dsv16x_den_conf_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_eis_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_eis_gy_full_scale_set(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_eis_gy_full_scale_t val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -2856,7 +2792,8 @@ int32_t lsm6dsv16x_eis_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl_eis.fs_g_eis = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
@@ -2872,18 +2809,17 @@ int32_t lsm6dsv16x_eis_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_eis_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_eis_gy_full_scale_t *val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl_eis.fs_g_eis) {
+  switch (ctrl_eis.fs_g_eis)
+  {
     case LSM6DSV16X_EIS_125dps:
       *val = LSM6DSV16X_EIS_125dps;
       break;
@@ -2919,14 +2855,15 @@ int32_t lsm6dsv16x_eis_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_eis_gy_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_eis_gy_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl_eis.g_eis_on_g_ois_out_reg = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
@@ -2942,7 +2879,7 @@ int32_t lsm6dsv16x_eis_gy_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_eis_gy_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_eis_gy_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
   int32_t ret;
@@ -2961,7 +2898,7 @@ int32_t lsm6dsv16x_eis_gy_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_eis_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_eis_data_rate_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_gy_eis_data_rate_t val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -2969,7 +2906,8 @@ int32_t lsm6dsv16x_gy_eis_data_rate_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl_eis.odr_g_eis = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
@@ -2985,18 +2923,17 @@ int32_t lsm6dsv16x_gy_eis_data_rate_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_gy_eis_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_gy_eis_data_rate_t *val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl_eis.odr_g_eis) {
+  switch (ctrl_eis.odr_g_eis)
+  {
     case LSM6DSV16X_EIS_ODR_OFF:
       *val = LSM6DSV16X_EIS_ODR_OFF;
       break;
@@ -3037,14 +2974,15 @@ int32_t lsm6dsv16x_gy_eis_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_watermark_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl1_t fifo_ctrl1;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl1.wtm = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL1, (uint8_t *)&fifo_ctrl1, 1);
   }
@@ -3060,7 +2998,7 @@ int32_t lsm6dsv16x_fifo_watermark_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_watermark_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl1_t fifo_ctrl1;
   int32_t ret;
@@ -3079,13 +3017,14 @@ int32_t lsm6dsv16x_fifo_watermark_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl2.xl_dualc_batch_from_fsm = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
@@ -3101,7 +3040,7 @@ int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3120,14 +3059,15 @@ int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_compress_algo_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_set(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_fifo_compress_algo_t val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl2.uncompr_rate = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
@@ -3143,18 +3083,17 @@ int32_t lsm6dsv16x_fifo_compress_algo_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_compress_algo_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_fifo_compress_algo_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (fifo_ctrl2.uncompr_rate) {
+  switch (fifo_ctrl2.uncompr_rate)
+  {
     case LSM6DSV16X_CMP_DISABLE:
       *val = LSM6DSV16X_CMP_DISABLE;
       break;
@@ -3186,13 +3125,14 @@ int32_t lsm6dsv16x_fifo_compress_algo_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl2.odr_chg_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
@@ -3208,7 +3148,7 @@ int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(lsm6dsv16x_ctx_t *ctx, uint8_t 
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
                                                  uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
@@ -3228,7 +3168,7 @@ int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(stmdev_ctx_t *ctx,
                                                     uint8_t val)
 {
   lsm6dsv16x_emb_func_en_b_t emb_func_en_b;
@@ -3239,14 +3179,10 @@ int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   fifo_ctrl2.fifo_compr_rt_en = val;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
   emb_func_en_b.fifo_compr_en = val;
@@ -3264,7 +3200,7 @@ int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(stmdev_ctx_t *ctx,
                                                     uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
@@ -3285,13 +3221,14 @@ int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_stop_on_wtm_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl2.stop_on_wtm = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL2, (uint8_t *)&fifo_ctrl2, 1);
   }
@@ -3307,7 +3244,7 @@ int32_t lsm6dsv16x_fifo_stop_on_wtm_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_stop_on_wtm_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl2_t fifo_ctrl2;
   int32_t ret;
@@ -3326,14 +3263,15 @@ int32_t lsm6dsv16x_fifo_stop_on_wtm_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_xl_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t val)
 {
   lsm6dsv16x_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl3.bdr_xl = (uint8_t)val & 0xFu;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
   }
@@ -3349,18 +3287,17 @@ int32_t lsm6dsv16x_fifo_xl_batch_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_xl_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t *val)
 {
   lsm6dsv16x_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (fifo_ctrl3.bdr_xl) {
+  switch (fifo_ctrl3.bdr_xl)
+  {
     case LSM6DSV16X_XL_NOT_BATCHED:
       *val = LSM6DSV16X_XL_NOT_BATCHED;
       break;
@@ -3429,14 +3366,15 @@ int32_t lsm6dsv16x_fifo_xl_batch_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_gy_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t val)
 {
   lsm6dsv16x_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl3.bdr_gy = (uint8_t)val & 0x0Fu;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
   }
@@ -3452,18 +3390,17 @@ int32_t lsm6dsv16x_fifo_gy_batch_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_gy_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t *val)
 {
   lsm6dsv16x_fifo_ctrl3_t fifo_ctrl3;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL3, (uint8_t *)&fifo_ctrl3, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (fifo_ctrl3.bdr_gy) {
+  switch (fifo_ctrl3.bdr_gy)
+  {
     case LSM6DSV16X_GY_NOT_BATCHED:
       *val = LSM6DSV16X_GY_NOT_BATCHED;
       break;
@@ -3532,13 +3469,14 @@ int32_t lsm6dsv16x_fifo_gy_batch_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val)
+int32_t lsm6dsv16x_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl4.fifo_mode = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
@@ -3554,17 +3492,16 @@ int32_t lsm6dsv16x_fifo_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fifo_mode_t v
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fifo_mode_t *val)
+int32_t lsm6dsv16x_fifo_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t *val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (fifo_ctrl4.fifo_mode) {
+  switch (fifo_ctrl4.fifo_mode)
+  {
     case LSM6DSV16X_BYPASS_MODE:
       *val = LSM6DSV16X_BYPASS_MODE;
       break;
@@ -3608,13 +3545,14 @@ int32_t lsm6dsv16x_fifo_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fifo_mode_t *
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_gy_eis_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_gy_eis_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl4.g_eis_fifo_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
@@ -3630,7 +3568,7 @@ int32_t lsm6dsv16x_fifo_gy_eis_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_gy_eis_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_gy_eis_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
@@ -3649,14 +3587,15 @@ int32_t lsm6dsv16x_fifo_gy_eis_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_temp_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_temp_batch_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl4.odr_t_batch = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
@@ -3672,18 +3611,17 @@ int32_t lsm6dsv16x_fifo_temp_batch_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_temp_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_temp_batch_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t *val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (fifo_ctrl4.odr_t_batch) {
+  switch (fifo_ctrl4.odr_t_batch)
+  {
     case LSM6DSV16X_TEMP_NOT_BATCHED:
       *val = LSM6DSV16X_TEMP_NOT_BATCHED;
       break;
@@ -3715,14 +3653,15 @@ int32_t lsm6dsv16x_fifo_temp_batch_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_timestamp_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_timestamp_batch_set(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_timestamp_batch_t val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fifo_ctrl4.dec_ts_batch = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
   }
@@ -3738,18 +3677,17 @@ int32_t lsm6dsv16x_fifo_timestamp_batch_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_timestamp_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_timestamp_batch_t *val)
 {
   lsm6dsv16x_fifo_ctrl4_t fifo_ctrl4;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_CTRL4, (uint8_t *)&fifo_ctrl4, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (fifo_ctrl4.dec_ts_batch) {
+  switch (fifo_ctrl4.dec_ts_batch)
+  {
     case LSM6DSV16X_TMSTMP_NOT_BATCHED:
       *val = LSM6DSV16X_TMSTMP_NOT_BATCHED;
       break;
@@ -3782,7 +3720,7 @@ int32_t lsm6dsv16x_fifo_timestamp_batch_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(stmdev_ctx_t *ctx,
                                                     uint16_t val)
 {
   uint8_t buff[2];
@@ -3803,16 +3741,14 @@ int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
                                                     uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, &buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -3828,14 +3764,15 @@ int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_cnt_event_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_cnt_event_set(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t val)
 {
   lsm6dsv16x_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     counter_bdr_reg1.trig_counter_bdr = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
   }
@@ -3851,18 +3788,17 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_batch_cnt_event_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t *val)
 {
   lsm6dsv16x_counter_bdr_reg1_t counter_bdr_reg1;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_COUNTER_BDR_REG1, (uint8_t *)&counter_bdr_reg1, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (counter_bdr_reg1.trig_counter_bdr) {
+  switch (counter_bdr_reg1.trig_counter_bdr)
+  {
     case LSM6DSV16X_XL_BATCH_EVENT:
       *val = LSM6DSV16X_XL_BATCH_EVENT;
       break;
@@ -3883,7 +3819,7 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_get(lsm6dsv16x_ctx_t *ctx,
   return ret;
 }
 
-int32_t lsm6dsv16x_fifo_status_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_status_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_fifo_status_t *val)
 {
   uint8_t buff[2];
@@ -3891,9 +3827,7 @@ int32_t lsm6dsv16x_fifo_status_get(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_STATUS1, (uint8_t *)&buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   bytecpy((uint8_t *)&status, &buff[1]);
 
@@ -3924,7 +3858,7 @@ int32_t lsm6dsv16x_fifo_status_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_out_raw_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_out_raw_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_fifo_out_raw_t *val)
 {
   lsm6dsv16x_fifo_data_out_tag_t fifo_data_out_tag;
@@ -3932,13 +3866,12 @@ int32_t lsm6dsv16x_fifo_out_raw_get(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FIFO_DATA_OUT_TAG, buff, 7);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   bytecpy((uint8_t *)&fifo_data_out_tag, &buff[0]);
 
-  switch (fifo_data_out_tag.tag_sensor) {
+  switch (fifo_data_out_tag.tag_sensor)
+  {
     case LSM6DSV16X_FIFO_EMPTY:
       val->tag = LSM6DSV16X_FIFO_EMPTY;
       break;
@@ -4076,15 +4009,13 @@ int32_t lsm6dsv16x_fifo_out_raw_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_stpcnt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   emb_func_fifo_en_a.step_counter_fifo_en = val;
@@ -4103,15 +4034,13 @@ int32_t lsm6dsv16x_fifo_stpcnt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_stpcnt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   *val = emb_func_fifo_en_a.step_counter_fifo_en;
@@ -4129,15 +4058,13 @@ int32_t lsm6dsv16x_fifo_stpcnt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mlc_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_mlc_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   emb_func_fifo_en_a.mlc_fifo_en = val;
@@ -4156,15 +4083,13 @@ int32_t lsm6dsv16x_fifo_mlc_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mlc_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_mlc_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
   *val = emb_func_fifo_en_a.mlc_fifo_en;
@@ -4182,15 +4107,13 @@ int32_t lsm6dsv16x_fifo_mlc_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
   emb_func_fifo_en_b.mlc_filter_feature_fifo_en = val;
@@ -4209,15 +4132,13 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_fifo_en_b_t emb_func_fifo_en_b;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_B, (uint8_t *)&emb_func_fifo_en_b, 1);
   *val = emb_func_fifo_en_b.mlc_filter_feature_fifo_en;
@@ -4235,19 +4156,17 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_sh_batch_slave_set(lsm6dsv16x_ctx_t *ctx, uint8_t idx, uint8_t val)
+int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val)
 {
   lsm6dsv16x_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U, (uint8_t *)&slv_config, 1);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
   slv_config.batch_ext_sens_0_en = val;
-  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U, (uint8_t *)&slv_config, 1);
+  ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
@@ -4262,17 +4181,15 @@ int32_t lsm6dsv16x_fifo_sh_batch_slave_set(lsm6dsv16x_ctx_t *ctx, uint8_t idx, u
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_sh_batch_slave_get(lsm6dsv16x_ctx_t *ctx, uint8_t idx, uint8_t *val)
+int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val)
 {
   lsm6dsv16x_slv0_config_t slv_config;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U, (uint8_t *)&slv_config, 1);
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U, (uint8_t *)&slv_config, 1);
   *val = slv_config.batch_ext_sens_0_en;
 
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -4288,14 +4205,15 @@ int32_t lsm6dsv16x_fifo_sh_batch_slave_get(lsm6dsv16x_ctx_t *ctx, uint8_t idx, u
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_sflp_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
     emb_func_fifo_en_a.sflp_game_fifo_en = val.game_rotation;
     emb_func_fifo_en_a.sflp_gravity_fifo_en = val.gravity;
@@ -4317,14 +4235,15 @@ int32_t lsm6dsv16x_fifo_sflp_batch_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fifo_sflp_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t *val)
 {
   lsm6dsv16x_emb_func_fifo_en_a_t emb_func_fifo_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_FIFO_EN_A, (uint8_t *)&emb_func_fifo_en_a, 1);
 
     val->game_rotation = emb_func_fifo_en_a.sflp_game_fifo_en;
@@ -4358,7 +4277,7 @@ int32_t lsm6dsv16x_fifo_sflp_batch_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_anti_spike_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_anti_spike_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
@@ -4366,7 +4285,8 @@ int32_t lsm6dsv16x_filt_anti_spike_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     if_cfg.asf_ctrl = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -4382,18 +4302,17 @@ int32_t lsm6dsv16x_filt_anti_spike_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_anti_spike_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (if_cfg.asf_ctrl) {
+  switch (if_cfg.asf_ctrl)
+  {
     case LSM6DSV16X_AUTO:
       *val = LSM6DSV16X_AUTO;
       break;
@@ -4418,7 +4337,7 @@ int32_t lsm6dsv16x_filt_anti_spike_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_settling_mask_set(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t val)
 {
   lsm6dsv16x_emb_func_cfg_t emb_func_cfg;
@@ -4429,17 +4348,13 @@ int32_t lsm6dsv16x_filt_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
   ctrl4.drdy_mask = val.drdy;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL4, (uint8_t *)&ctrl4, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
   emb_func_cfg.emb_func_irq_mask_xl_settl = val.irq_xl;
   emb_func_cfg.emb_func_irq_mask_g_settl = val.irq_g;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_CFG, (uint8_t *)&emb_func_cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_INT_OIS, (uint8_t *)&ui_int_ois, 1);
   ui_int_ois.drdy_mask_ois = val.ois_drdy;
@@ -4456,7 +4371,7 @@ int32_t lsm6dsv16x_filt_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_settling_mask_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t *val)
 {
   lsm6dsv16x_emb_func_cfg_t emb_func_cfg;
@@ -4483,7 +4398,7 @@ int32_t lsm6dsv16x_filt_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_ois_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_ois_settling_mask_set(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t val)
 {
   lsm6dsv16x_spi2_int_ois_t spi2_int_ois;
@@ -4491,7 +4406,8 @@ int32_t lsm6dsv16x_filt_ois_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     spi2_int_ois.drdy_mask_ois = val.ois_drdy;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SPI2_INT_OIS, (uint8_t *)&spi2_int_ois, 1);
   }
@@ -4507,7 +4423,7 @@ int32_t lsm6dsv16x_filt_ois_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_ois_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_ois_settling_mask_get(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t *val)
 {
 
@@ -4528,14 +4444,15 @@ int32_t lsm6dsv16x_filt_ois_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_filt_gy_lp1_bandwidth_t val)
 {
   lsm6dsv16x_ctrl6_t ctrl6;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl6.lpf1_g_bw = (uint8_t)val & 0x0Fu;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
   }
@@ -4551,18 +4468,17 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_filt_gy_lp1_bandwidth_t *val)
 {
   lsm6dsv16x_ctrl6_t ctrl6;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL6, (uint8_t *)&ctrl6, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl6.lpf1_g_bw) {
+  switch (ctrl6.lpf1_g_bw)
+  {
     case LSM6DSV16X_GY_ULTRA_LIGHT:
       *val = LSM6DSV16X_GY_ULTRA_LIGHT;
       break;
@@ -4611,13 +4527,14 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_lp1_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_filt_gy_lp1_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl7.lpf1_g_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
@@ -4634,7 +4551,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_lp1_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_filt_gy_lp1_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
   int32_t ret;
@@ -4653,14 +4570,15 @@ int32_t lsm6dsv16x_filt_gy_lp1_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_filt_xl_lp2_bandwidth_t val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl8.hp_lpf2_xl_bw = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
   }
@@ -4676,18 +4594,17 @@ int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_filt_xl_lp2_bandwidth_t *val)
 {
   lsm6dsv16x_ctrl8_t ctrl8;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL8, (uint8_t *)&ctrl8, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl8.hp_lpf2_xl_bw) {
+  switch (ctrl8.hp_lpf2_xl_bw)
+  {
     case LSM6DSV16X_XL_ULTRA_LIGHT:
       *val = LSM6DSV16X_XL_ULTRA_LIGHT;
       break;
@@ -4736,13 +4653,14 @@ int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_lp2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_filt_xl_lp2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl9.lpf2_xl_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -4758,7 +4676,7 @@ int32_t lsm6dsv16x_filt_xl_lp2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_lp2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_filt_xl_lp2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4777,13 +4695,14 @@ int32_t lsm6dsv16x_filt_xl_lp2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_hp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_filt_xl_hp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl9.hp_slope_xl_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -4799,7 +4718,7 @@ int32_t lsm6dsv16x_filt_xl_hp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_hp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_filt_xl_hp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4818,13 +4737,14 @@ int32_t lsm6dsv16x_filt_xl_hp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_fast_settling_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_filt_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl9.xl_fastsettl_mode = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -4840,7 +4760,7 @@ int32_t lsm6dsv16x_filt_xl_fast_settling_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_fast_settling_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_filt_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
@@ -4859,14 +4779,15 @@ int32_t lsm6dsv16x_filt_xl_fast_settling_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_hp_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_hp_mode_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl9.hp_ref_mode_xl = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
   }
@@ -4882,18 +4803,17 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_hp_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t *val)
 {
   lsm6dsv16x_ctrl9_t ctrl9;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL9, (uint8_t *)&ctrl9, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl9.hp_ref_mode_xl) {
+  switch (ctrl9.hp_ref_mode_xl)
+  {
     case LSM6DSV16X_HP_MD_NORMAL:
       *val = LSM6DSV16X_HP_MD_NORMAL;
       break;
@@ -4918,7 +4838,7 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_wkup_act_feed_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_wkup_act_feed_set(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_wkup_act_feed_t val)
 {
   lsm6dsv16x_wake_up_ths_t wake_up_ths;
@@ -4927,15 +4847,11 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   tap_cfg0.slope_fds = (uint8_t)val & 0x01U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   wake_up_ths.usr_off_on_wu = ((uint8_t)val & 0x02U) >> 1;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
@@ -4951,7 +4867,7 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_wkup_act_feed_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_wkup_act_feed_t *val)
 {
   lsm6dsv16x_wake_up_ths_t wake_up_ths;
@@ -4960,11 +4876,10 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_get(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch ((wake_up_ths.usr_off_on_wu << 1) + tap_cfg0.slope_fds) {
+  switch ((wake_up_ths.usr_off_on_wu << 1) + tap_cfg0.slope_fds)
+  {
     case LSM6DSV16X_WK_FEED_SLOPE:
       *val = LSM6DSV16X_WK_FEED_SLOPE;
       break;
@@ -4993,14 +4908,15 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mask_trigger_xl_settl_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_mask_trigger_xl_settl_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     tap_cfg0.hw_func_mask_xl_settl = val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
   }
@@ -5016,7 +4932,7 @@ int32_t lsm6dsv16x_mask_trigger_xl_settl_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mask_trigger_xl_settl_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_mask_trigger_xl_settl_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
   int32_t ret;
@@ -5035,7 +4951,7 @@ int32_t lsm6dsv16x_mask_trigger_xl_settl_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_sixd_feed_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_sixd_feed_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
@@ -5043,7 +4959,8 @@ int32_t lsm6dsv16x_filt_sixd_feed_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     tap_cfg0.low_pass_on_6d = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
   }
@@ -5059,18 +4976,17 @@ int32_t lsm6dsv16x_filt_sixd_feed_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_sixd_feed_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t *val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (tap_cfg0.low_pass_on_6d) {
+  switch (tap_cfg0.low_pass_on_6d)
+  {
     case LSM6DSV16X_SIXD_FEED_ODR_DIV_2:
       *val = LSM6DSV16X_SIXD_FEED_ODR_DIV_2;
       break;
@@ -5095,7 +5011,7 @@ int32_t lsm6dsv16x_filt_sixd_feed_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
@@ -5103,7 +5019,8 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl_eis.lpf_g_eis_bw = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
   }
@@ -5119,18 +5036,17 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t *val)
 {
   lsm6dsv16x_ctrl_eis_t ctrl_eis;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL_EIS, (uint8_t *)&ctrl_eis, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl_eis.lpf_g_eis_bw) {
+  switch (ctrl_eis.lpf_g_eis_bw)
+  {
     case LSM6DSV16X_EIS_LP_NORMAL:
       *val = LSM6DSV16X_EIS_LP_NORMAL;
       break;
@@ -5155,7 +5071,7 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t val)
 {
   lsm6dsv16x_ui_ctrl2_ois_t ui_ctrl2_ois;
@@ -5163,7 +5079,8 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ui_ctrl2_ois.lpf1_g_ois_bw = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
   }
@@ -5179,7 +5096,7 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t *val)
 {
 
@@ -5187,11 +5104,10 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ui_ctrl2_ois.lpf1_g_ois_bw) {
+  switch (ui_ctrl2_ois.lpf1_g_ois_bw)
+  {
     case LSM6DSV16X_OIS_GY_LP_NORMAL:
       *val = LSM6DSV16X_OIS_GY_LP_NORMAL;
       break;
@@ -5224,7 +5140,7 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t val)
 {
   lsm6dsv16x_ui_ctrl3_ois_t ui_ctrl3_ois;
@@ -5232,7 +5148,8 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ui_ctrl3_ois.lpf_xl_ois_bw = (uint8_t)val & 0x07U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
   }
@@ -5248,18 +5165,17 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t *val)
 {
   lsm6dsv16x_ui_ctrl3_ois_t ui_ctrl3_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ui_ctrl3_ois.lpf_xl_ois_bw) {
+  switch (ui_ctrl3_ois.lpf_xl_ois_bw)
+  {
     case LSM6DSV16X_OIS_XL_LP_ULTRA_LIGHT:
       *val = LSM6DSV16X_OIS_XL_LP_ULTRA_LIGHT;
       break;
@@ -5321,7 +5237,7 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_permission_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_permission_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
@@ -5329,7 +5245,8 @@ int32_t lsm6dsv16x_fsm_permission_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     func_cfg_access.fsm_wr_ctrl_en = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
@@ -5345,18 +5262,17 @@ int32_t lsm6dsv16x_fsm_permission_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_permission_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (func_cfg_access.fsm_wr_ctrl_en) {
+  switch (func_cfg_access.fsm_wr_ctrl_en)
+  {
     case LSM6DSV16X_PROTECT_CTRL_REGS:
       *val = LSM6DSV16X_PROTECT_CTRL_REGS;
       break;
@@ -5381,7 +5297,7 @@ int32_t lsm6dsv16x_fsm_permission_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_permission_status(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fsm_permission_status(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ctrl_status_t ctrl_status;
   int32_t ret;
@@ -5401,27 +5317,26 @@ int32_t lsm6dsv16x_fsm_permission_status(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val)
+int32_t lsm6dsv16x_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val)
 {
   lsm6dsv16x_emb_func_en_b_t emb_func_en_b;
   lsm6dsv16x_fsm_enable_t fsm_enable;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
-  if ((val.fsm1_en | val.fsm2_en | val.fsm1_en | val.fsm1_en
-       | val.fsm1_en | val.fsm2_en | val.fsm1_en | val.fsm1_en) == PROPERTY_ENABLE) {
+  if ((val.fsm1_en | val.fsm2_en | val.fsm3_en | val.fsm4_en
+       | val.fsm5_en | val.fsm6_en | val.fsm7_en | val.fsm8_en) == PROPERTY_ENABLE)
+  {
     emb_func_en_b.fsm_en = PROPERTY_ENABLE;
-  } else {
+  }
+  else
+  {
     emb_func_en_b.fsm_en = PROPERTY_DISABLE;
   }
 
@@ -5451,7 +5366,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val)
+int32_t lsm6dsv16x_fsm_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val)
 {
   lsm6dsv16x_fsm_enable_t fsm_enable;
   int32_t ret;
@@ -5459,9 +5374,7 @@ int32_t lsm6dsv16x_fsm_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *va
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ENABLE, (uint8_t *)&fsm_enable, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->fsm1_en = fsm_enable.fsm1_en;
   val->fsm2_en = fsm_enable.fsm2_en;
@@ -5483,7 +5396,7 @@ int32_t lsm6dsv16x_fsm_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_long_cnt_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_fsm_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -5506,7 +5419,7 @@ int32_t lsm6dsv16x_fsm_long_cnt_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_long_cnt_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -5514,9 +5427,7 @@ int32_t lsm6dsv16x_fsm_long_cnt_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_LONG_COUNTER_L, &buff[0], 2);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -5532,7 +5443,7 @@ int32_t lsm6dsv16x_fsm_long_cnt_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val)
+int32_t lsm6dsv16x_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val)
 {
   int32_t ret;
 
@@ -5551,7 +5462,7 @@ int32_t lsm6dsv16x_fsm_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_data_rate_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fsm_data_rate_t val)
 {
   lsm6dsv16x_fsm_odr_t fsm_odr;
@@ -5559,9 +5470,7 @@ int32_t lsm6dsv16x_fsm_data_rate_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   fsm_odr.fsm_odr = (uint8_t)val & 0x07U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
@@ -5580,7 +5489,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_data_rate_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fsm_data_rate_t *val)
 {
   lsm6dsv16x_fsm_odr_t fsm_odr;
@@ -5589,11 +5498,10 @@ int32_t lsm6dsv16x_fsm_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FSM_ODR, (uint8_t *)&fsm_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (fsm_odr.fsm_odr) {
+  switch (fsm_odr.fsm_odr)
+  {
     case LSM6DSV16X_FSM_15Hz:
       *val = LSM6DSV16X_FSM_15Hz;
       break;
@@ -5647,23 +5555,31 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
   f_exp = (f & 0x7f800000u);
 
   /* Exponent overflow/NaN converts to signed inf/NaN */
-  if (f_exp >= 0x47800000u) {
-    if (f_exp == 0x7f800000u) {
+  if (f_exp >= 0x47800000u)
+  {
+    if (f_exp == 0x7f800000u)
+    {
       /* Inf or NaN */
       f_sig = (f & 0x007fffffu);
-      if (f_sig != 0U) {
+      if (f_sig != 0U)
+      {
         /* NaN - propagate the flag in the significand... */
         uint16_t ret = (uint16_t)(0x7c00u + (f_sig >> 13));
         /* ...but make sure it stays a NaN */
-        if (ret == 0x7c00u) {
+        if (ret == 0x7c00u)
+        {
           ret++;
         }
         return h_sgn + ret;
-      } else {
+      }
+      else
+      {
         /* signed inf */
         return (uint16_t)(h_sgn + 0x7c00u);
       }
-    } else {
+    }
+    else
+    {
       /* overflow to signed inf */
 #if NPY_HALF_GENERATE_OVERFLOW
       npy_set_floatstatus_overflow();
@@ -5673,15 +5589,18 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
   }
 
   /* Exponent underflow converts to a subnormal half or signed zero */
-  if (f_exp <= 0x38000000u) {
+  if (f_exp <= 0x38000000u)
+  {
     /*
      * Signed zeros, subnormal floats, and floats with small
      * exponents all convert to signed zero half-floats.
      */
-    if (f_exp < 0x33000000u) {
+    if (f_exp < 0x33000000u)
+    {
 #if NPY_HALF_GENERATE_UNDERFLOW
       /* If f != 0, it underflowed to 0 */
-      if ((f & 0x7fffffff) != 0) {
+      if ((f & 0x7fffffff) != 0)
+      {
         npy_set_floatstatus_underflow();
       }
 #endif
@@ -5692,7 +5611,8 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
     f_sig = (0x00800000u + (f & 0x007fffffu));
 #if NPY_HALF_GENERATE_UNDERFLOW
     /* If it's not exactly represented, it underflowed */
-    if ((f_sig & (((uint32_t)1 << (126 - f_exp)) - 1)) != 0) {
+    if ((f_sig & (((uint32_t)1 << (126 - f_exp)) - 1)) != 0)
+    {
       npy_set_floatstatus_underflow();
     }
 #endif
@@ -5712,7 +5632,8 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
      * shift can lose up to 11 bits, so the || checks them in the original.
      * In all other cases, we can just add one.
      */
-    if (((f_sig & 0x00003fffu) != 0x00001000u) || (f & 0x000007ffu)) {
+    if (((f_sig & 0x00003fffu) != 0x00001000u) || (f & 0x000007ffu))
+    {
       f_sig += 0x00001000u;
     }
 #else
@@ -5737,7 +5658,8 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
    * the remaining bit pattern is 1000...0, then we do not add one
    * to the bit after the half significand.  In all other cases, we do.
    */
-  if ((f_sig & 0x00003fffu) != 0x00001000u) {
+  if ((f_sig & 0x00003fffu) != 0x00001000u)
+  {
     f_sig += 0x00001000u;
   }
 #else
@@ -5752,7 +5674,8 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
    */
 #if NPY_HALF_GENERATE_OVERFLOW
   h_sig += h_exp;
-  if (h_sig == 0x7c00u) {
+  if (h_sig == 0x7c00u)
+  {
     npy_set_floatstatus_overflow();
   }
   return h_sgn + h_sig;
@@ -5763,7 +5686,8 @@ static uint16_t npy_floatbits_to_halfbits(uint32_t f)
 
 static uint16_t npy_float_to_half(float_t f)
 {
-  union {
+  union
+  {
     float_t f;
     uint32_t fbits;
   } conv;
@@ -5781,7 +5705,7 @@ static uint16_t npy_float_to_half(float_t f)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_sflp_gbias_t *val)
 {
   lsm6dsv16x_sflp_data_rate_t sflp_odr;
@@ -5802,12 +5726,11 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_sflp_data_rate_get(ctx, &sflp_odr);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   /* Calculate k factor */
-  switch (sflp_odr) {
+  switch (sflp_odr)
+  {
     default:
     case LSM6DSV16X_SFLP_15Hz:
       k = 0.04f;
@@ -5838,7 +5761,8 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL1, conf_saved, 2);
   ret += lsm6dsv16x_xl_mode_set(ctx, LSM6DSV16X_XL_HIGH_PERFORMANCE_MD);
   ret += lsm6dsv16x_gy_mode_set(ctx, LSM6DSV16X_GY_HIGH_PERFORMANCE_MD);
-  if (((uint8_t)conf_saved[0] & 0x0FU) == (uint8_t)LSM6DSV16X_ODR_OFF) {
+  if (((uint8_t)conf_saved[0] & 0x0FU) == (uint8_t)LSM6DSV16X_ODR_OFF)
+  {
     ret += lsm6dsv16x_xl_data_rate_set(ctx, LSM6DSV16X_ODR_AT_120Hz);
   }
 
@@ -5850,7 +5774,8 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, emb_func_en_saved, 2);
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, reg_zero, 2);
-  do {
+  do
+  {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EXEC_STATUS,
                                (uint8_t *)&emb_func_sts, 1);
   } while (emb_func_sts.emb_func_endop != 1U);
@@ -5871,14 +5796,16 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
   ret += lsm6dsv16x_xl_full_scale_get(ctx, &xl_fs);
 
   /* Read XL data */
-  do {
+  do
+  {
     ret += lsm6dsv16x_flag_data_ready_get(ctx, &drdy);
   } while (drdy.drdy_xl != 1U);
   ret += lsm6dsv16x_acceleration_raw_get(ctx, xl_data);
 
   /* force sflp initialization */
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  for (i = 0; i < 3U; i++) {
+  for (i = 0; i < 3U; i++)
+  {
     j = 0;
     data_tmp = (int32_t)xl_data[i];
     data_tmp <<= xl_fs; // shift based on current fs
@@ -5889,7 +5816,8 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SENSOR_HUB_3 + 3U * i, &data_ptr[j],
                                 1);
   }
-  for (i = 0; i < 3U; i++) {
+  for (i = 0; i < 3U; i++)
+  {
     j = 0;
     data_tmp = 0;
     ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SENSOR_HUB_10 + 3U * i,
@@ -5904,7 +5832,8 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
   // wait end_op (and at least 30 us)
   ctx->mdelay(1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  do {
+  do
+  {
     ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EXEC_STATUS,
                                (uint8_t *)&emb_func_sts, 1);
   } while (emb_func_sts.emb_func_endop != 1U);
@@ -5935,7 +5864,7 @@ int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -5955,16 +5884,14 @@ int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx, uint16_t 
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
                                                 uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_SENSITIVITY_L, &buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -5980,7 +5907,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_offset_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_offset_set(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t val)
 {
   uint8_t buff[6];
@@ -6005,16 +5932,14 @@ int32_t lsm6dsv16x_fsm_ext_sens_offset_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_offset_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t *val)
 {
   uint8_t buff[6];
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_OFFX_L, &buff[0], 6);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->x = buff[1];
   val->x = (val->x * 256U) + buff[0];
@@ -6034,7 +5959,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_offset_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t val)
 {
   uint8_t buff[12];
@@ -6065,16 +5990,14 @@ int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t *val)
 {
   uint8_t buff[12];
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_FSM_EXT_MATRIX_XX_L, &buff[0], 12);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->xx = buff[1];
   val->xx = (val->xx * 256U) + buff[0];
@@ -6100,7 +6023,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t val)
 {
   lsm6dsv16x_ext_cfg_a_t ext_cfg_a;
@@ -6121,18 +6044,17 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t *val)
 {
   lsm6dsv16x_ext_cfg_a_t ext_cfg_a;
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ext_cfg_a.ext_z_axis) {
+  switch (ext_cfg_a.ext_z_axis)
+  {
     case LSM6DSV16X_Z_EQ_Y:
       *val = LSM6DSV16X_Z_EQ_Y;
       break;
@@ -6173,14 +6095,15 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t val)
 {
   lsm6dsv16x_ext_cfg_a_t ext_cfg_a;
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ext_cfg_a.ext_y_axis = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
   }
@@ -6196,18 +6119,17 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t *val)
 {
   lsm6dsv16x_ext_cfg_a_t ext_cfg_a;
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_A, (uint8_t *)&ext_cfg_a, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ext_cfg_a.ext_y_axis) {
+  switch (ext_cfg_a.ext_y_axis)
+  {
     case LSM6DSV16X_Y_EQ_Y:
       *val = LSM6DSV16X_Y_EQ_Y;
       break;
@@ -6248,14 +6170,15 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_x_orient_t val)
 {
   lsm6dsv16x_ext_cfg_b_t ext_cfg_b;
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ext_cfg_b.ext_x_axis = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
   }
@@ -6271,18 +6194,17 @@ int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_x_orient_t *val)
 {
   lsm6dsv16x_ext_cfg_b_t ext_cfg_b;
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EXT_CFG_B, (uint8_t *)&ext_cfg_b, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ext_cfg_b.ext_x_axis) {
+  switch (ext_cfg_b.ext_x_axis)
+  {
     case LSM6DSV16X_X_EQ_Y:
       *val = LSM6DSV16X_X_EQ_Y;
       break;
@@ -6323,7 +6245,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -6343,15 +6265,13 @@ int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_LC_TIMEOUT_L, &buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -6367,13 +6287,14 @@ int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_number_of_programs_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_fsm_number_of_programs_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_fsm_programs_t fsm_programs;
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_PROGRAMS, (uint8_t *)&fsm_programs, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     fsm_programs.fsm_n_prog = val;
     ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_PROGRAMS, (uint8_t *)&fsm_programs, 1);
   }
@@ -6389,7 +6310,7 @@ int32_t lsm6dsv16x_fsm_number_of_programs_set(lsm6dsv16x_ctx_t *ctx, uint8_t val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_number_of_programs_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_fsm_number_of_programs_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_fsm_programs_t fsm_programs;
   int32_t ret;
@@ -6408,7 +6329,7 @@ int32_t lsm6dsv16x_fsm_number_of_programs_get(lsm6dsv16x_ctx_t *ctx, uint8_t *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_start_address_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_fsm_start_address_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -6428,15 +6349,13 @@ int32_t lsm6dsv16x_fsm_start_address_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_fsm_start_address_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_FSM_START_ADD_L, &buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -6465,7 +6384,7 @@ int32_t lsm6dsv16x_fsm_start_address_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ff_time_windows_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_wake_up_dur_t wake_up_dur;
   lsm6dsv16x_free_fall_t free_fall;
@@ -6474,9 +6393,7 @@ int32_t lsm6dsv16x_ff_time_windows_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
   wake_up_dur.ff_dur = ((uint8_t)val & 0x20U) >> 5;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
   free_fall.ff_dur = (uint8_t)val & 0x1FU;
@@ -6493,7 +6410,7 @@ int32_t lsm6dsv16x_ff_time_windows_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ff_time_windows_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ff_time_windows_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_wake_up_dur_t wake_up_dur;
   lsm6dsv16x_free_fall_t free_fall;
@@ -6515,14 +6432,15 @@ int32_t lsm6dsv16x_ff_time_windows_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ff_thresholds_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ff_thresholds_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t val)
 {
   lsm6dsv16x_free_fall_t free_fall;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     free_fall.ff_ths = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
   }
@@ -6538,18 +6456,17 @@ int32_t lsm6dsv16x_ff_thresholds_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ff_thresholds_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t *val)
 {
   lsm6dsv16x_free_fall_t free_fall;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FREE_FALL, (uint8_t *)&free_fall, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (free_fall.ff_ths) {
+  switch (free_fall.ff_ths)
+  {
     case LSM6DSV16X_156_mg:
       *val = LSM6DSV16X_156_mg;
       break;
@@ -6611,7 +6528,7 @@ int32_t lsm6dsv16x_ff_thresholds_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val)
+int32_t lsm6dsv16x_mlc_set(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val)
 {
   lsm6dsv16x_emb_func_en_b_t emb_en_b;
   lsm6dsv16x_emb_func_en_a_t emb_en_a;
@@ -6620,11 +6537,10 @@ int32_t lsm6dsv16x_mlc_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
-  switch (val) {
+  switch(val)
+  {
     case LSM6DSV16X_MLC_OFF:
       emb_en_a.mlc_before_fsm_en = 0;
       emb_en_b.mlc_en = 0;
@@ -6658,7 +6574,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val)
+int32_t lsm6dsv16x_mlc_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val)
 {
   lsm6dsv16x_emb_func_en_b_t emb_en_b;
   lsm6dsv16x_emb_func_en_a_t emb_en_a;
@@ -6667,18 +6583,23 @@ int32_t lsm6dsv16x_mlc_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_en_a, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_en_b, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
-  if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U) {
+  if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 0U)
+  {
     *val = LSM6DSV16X_MLC_OFF;
-  } else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U) {
+  }
+  else if (emb_en_a.mlc_before_fsm_en == 0U && emb_en_b.mlc_en == 1U)
+  {
     *val = LSM6DSV16X_MLC_ON;
-  } else if (emb_en_a.mlc_before_fsm_en == 1U) {
+  }
+  else if (emb_en_a.mlc_before_fsm_en == 1U)
+  {
     *val = LSM6DSV16X_MLC_ON_BEFORE_FSM;
-  } else {
-    /* Do nothing */
+  }
+  else
+  {
+      /* Do nothing */
   }
 
 exit:
@@ -6695,7 +6616,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_data_rate_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t val)
 {
   lsm6dsv16x_mlc_odr_t mlc_odr;
@@ -6703,9 +6624,7 @@ int32_t lsm6dsv16x_mlc_data_rate_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   mlc_odr.mlc_odr = (uint8_t)val & 0x07U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
@@ -6724,7 +6643,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t *val)
 {
   lsm6dsv16x_mlc_odr_t mlc_odr;
@@ -6733,11 +6652,10 @@ int32_t lsm6dsv16x_mlc_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC_ODR, (uint8_t *)&mlc_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (mlc_odr.mlc_odr) {
+  switch (mlc_odr.mlc_odr)
+  {
     case LSM6DSV16X_MLC_15Hz:
       *val = LSM6DSV16X_MLC_15Hz;
       break;
@@ -6782,12 +6700,13 @@ int32_t lsm6dsv16x_mlc_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val)
+int32_t lsm6dsv16x_mlc_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val)
 {
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MLC1_SRC, (uint8_t *)val, 4);
   }
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
@@ -6803,7 +6722,7 @@ int32_t lsm6dsv16x_mlc_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -6824,16 +6743,14 @@ int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx, uint16_t 
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
                                                 uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_MLC_EXT_SENSITIVITY_L, &buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -6862,14 +6779,15 @@ int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_ctrl_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_ctrl_mode_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ois_ctrl_mode_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     func_cfg_access.ois_ctrl_from_ui = (uint8_t)val & 0x1U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
@@ -6885,18 +6803,17 @@ int32_t lsm6dsv16x_ois_ctrl_mode_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_ctrl_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ois_ctrl_mode_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (func_cfg_access.ois_ctrl_from_ui) {
+  switch (func_cfg_access.ois_ctrl_from_ui)
+  {
     case LSM6DSV16X_OIS_CTRL_FROM_OIS:
       *val = LSM6DSV16X_OIS_CTRL_FROM_OIS;
       break;
@@ -6921,13 +6838,14 @@ int32_t lsm6dsv16x_ois_ctrl_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_reset_set(lsm6dsv16x_ctx_t *ctx, int8_t val)
+int32_t lsm6dsv16x_ois_reset_set(stmdev_ctx_t *ctx, int8_t val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     func_cfg_access.spi2_reset = (uint8_t)val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNC_CFG_ACCESS, (uint8_t *)&func_cfg_access, 1);
   }
@@ -6943,7 +6861,7 @@ int32_t lsm6dsv16x_ois_reset_set(lsm6dsv16x_ctx_t *ctx, int8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_reset_get(lsm6dsv16x_ctx_t *ctx, int8_t *val)
+int32_t lsm6dsv16x_ois_reset_get(stmdev_ctx_t *ctx, int8_t *val)
 {
   lsm6dsv16x_func_cfg_access_t func_cfg_access;
   int32_t ret;
@@ -6962,13 +6880,14 @@ int32_t lsm6dsv16x_ois_reset_get(lsm6dsv16x_ctx_t *ctx, int8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ois_interface_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     pin_ctrl.ois_pu_dis = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
@@ -6984,7 +6903,7 @@ int32_t lsm6dsv16x_ois_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ois_interface_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
@@ -7003,14 +6922,15 @@ int32_t lsm6dsv16x_ois_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_handshake_from_ui_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ui_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_ois_handshake_t val)
 {
   lsm6dsv16x_ui_handshake_ctrl_t ui_handshake_ctrl;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ui_handshake_ctrl.ui_shared_ack = val.ack;
     ui_handshake_ctrl.ui_shared_req = val.req;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
@@ -7027,16 +6947,14 @@ int32_t lsm6dsv16x_ois_handshake_from_ui_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_handshake_from_ui_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ui_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_ois_handshake_t *val)
 {
   lsm6dsv16x_ui_handshake_ctrl_t ui_handshake_ctrl;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_HANDSHAKE_CTRL, (uint8_t *)&ui_handshake_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->ack = ui_handshake_ctrl.ui_shared_ack;
   val->req = ui_handshake_ctrl.ui_shared_req;
@@ -7052,14 +6970,15 @@ int32_t lsm6dsv16x_ois_handshake_from_ui_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_handshake_from_ois_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ois_set(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_ois_handshake_t val)
 {
   lsm6dsv16x_spi2_handshake_ctrl_t spi2_handshake_ctrl;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_HANDSHAKE_CTRL, (uint8_t *)&spi2_handshake_ctrl, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     spi2_handshake_ctrl.spi2_shared_ack = val.ack;
     spi2_handshake_ctrl.spi2_shared_req = val.req;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SPI2_HANDSHAKE_CTRL, (uint8_t *)&spi2_handshake_ctrl, 1);
@@ -7076,16 +6995,14 @@ int32_t lsm6dsv16x_ois_handshake_from_ois_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_handshake_from_ois_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ois_get(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_ois_handshake_t *val)
 {
   lsm6dsv16x_spi2_handshake_ctrl_t spi2_handshake_ctrl;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SPI2_HANDSHAKE_CTRL, (uint8_t *)&spi2_handshake_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->ack = spi2_handshake_ctrl.spi2_shared_ack;
   val->req = spi2_handshake_ctrl.spi2_shared_req;
@@ -7101,7 +7018,7 @@ int32_t lsm6dsv16x_ois_handshake_from_ois_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_shared_set(lsm6dsv16x_ctx_t *ctx, uint8_t val[6])
+int32_t lsm6dsv16x_ois_shared_set(stmdev_ctx_t *ctx, uint8_t val[6])
 {
   int32_t ret;
 
@@ -7118,7 +7035,7 @@ int32_t lsm6dsv16x_ois_shared_set(lsm6dsv16x_ctx_t *ctx, uint8_t val[6])
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_shared_get(lsm6dsv16x_ctx_t *ctx, uint8_t val[6])
+int32_t lsm6dsv16x_ois_shared_get(stmdev_ctx_t *ctx, uint8_t val[6])
 {
   int32_t ret;
 
@@ -7135,13 +7052,14 @@ int32_t lsm6dsv16x_ois_shared_get(lsm6dsv16x_ctx_t *ctx, uint8_t val[6])
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ois_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ui_ctrl1_ois.spi2_read_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
   }
@@ -7157,7 +7075,7 @@ int32_t lsm6dsv16x_ois_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ois_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
@@ -7176,13 +7094,14 @@ int32_t lsm6dsv16x_ois_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_chain_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_ois_chain_t val)
+int32_t lsm6dsv16x_ois_chain_set(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ui_ctrl1_ois.ois_g_en = val.gy;
     ui_ctrl1_ois.ois_xl_en = val.xl;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
@@ -7199,15 +7118,13 @@ int32_t lsm6dsv16x_ois_chain_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_ois_chain_t v
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_chain_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_ois_chain_t *val)
+int32_t lsm6dsv16x_ois_chain_get(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t *val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->gy = ui_ctrl1_ois.ois_g_en;
   val->xl = ui_ctrl1_ois.ois_xl_en;
@@ -7223,14 +7140,15 @@ int32_t lsm6dsv16x_ois_chain_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_ois_chain_t *
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_full_scale_set(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t val)
 {
   lsm6dsv16x_ui_ctrl2_ois_t ui_ctrl2_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ui_ctrl2_ois.fs_g_ois = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
   }
@@ -7246,18 +7164,17 @@ int32_t lsm6dsv16x_ois_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t *val)
 {
   lsm6dsv16x_ui_ctrl2_ois_t ui_ctrl2_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL2_OIS, (uint8_t *)&ui_ctrl2_ois, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ui_ctrl2_ois.fs_g_ois) {
+  switch (ui_ctrl2_ois.fs_g_ois)
+  {
     case LSM6DSV16X_OIS_125dps:
       *val = LSM6DSV16X_OIS_125dps;
       break;
@@ -7294,14 +7211,15 @@ int32_t lsm6dsv16x_ois_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_full_scale_set(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t val)
 {
   lsm6dsv16x_ui_ctrl3_ois_t ui_ctrl3_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ui_ctrl3_ois.fs_xl_ois = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
   }
@@ -7317,18 +7235,17 @@ int32_t lsm6dsv16x_ois_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ois_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t *val)
 {
   lsm6dsv16x_ui_ctrl3_ois_t ui_ctrl3_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL3_OIS, (uint8_t *)&ui_ctrl3_ois, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ui_ctrl3_ois.fs_xl_ois) {
+  switch (ui_ctrl3_ois.fs_xl_ois)
+  {
     case LSM6DSV16X_OIS_2g:
       *val = LSM6DSV16X_OIS_2g;
       break;
@@ -7374,14 +7291,15 @@ int32_t lsm6dsv16x_ois_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_6d_threshold_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_6d_threshold_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_6d_threshold_t val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     tap_ths_6d.sixd_ths = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   }
@@ -7397,18 +7315,17 @@ int32_t lsm6dsv16x_6d_threshold_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_6d_threshold_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_6d_threshold_t *val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (tap_ths_6d.sixd_ths) {
+  switch (tap_ths_6d.sixd_ths)
+  {
     case LSM6DSV16X_DEG_80:
       *val = LSM6DSV16X_DEG_80;
       break;
@@ -7441,13 +7358,14 @@ int32_t lsm6dsv16x_6d_threshold_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_4d_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     tap_ths_6d.d4d_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
   }
@@ -7463,7 +7381,7 @@ int32_t lsm6dsv16x_4d_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_4d_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
   int32_t ret;
@@ -7495,14 +7413,15 @@ int32_t lsm6dsv16x_4d_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_zin_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_zin_set(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl7.ah_qvar_c_zin = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
@@ -7518,18 +7437,17 @@ int32_t lsm6dsv16x_ah_qvar_zin_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_zin_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t *val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl7.ah_qvar_c_zin) {
+  switch (ctrl7.ah_qvar_c_zin)
+  {
     case LSM6DSV16X_2400MOhm:
       *val = LSM6DSV16X_2400MOhm;
       break;
@@ -7562,14 +7480,15 @@ int32_t lsm6dsv16x_ah_qvar_zin_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl7.ah_qvar_en = val.ah_qvar_en;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL7, (uint8_t *)&ctrl7, 1);
   }
@@ -7585,7 +7504,7 @@ int32_t lsm6dsv16x_ah_qvar_mode_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ah_qvar_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t *val)
 {
   lsm6dsv16x_ctrl7_t ctrl7;
@@ -7618,14 +7537,15 @@ int32_t lsm6dsv16x_ah_qvar_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_i3c_reset_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_reset_mode_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     pin_ctrl.ibhr_por_en = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
@@ -7641,18 +7561,17 @@ int32_t lsm6dsv16x_i3c_reset_mode_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_i3c_reset_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t *val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (pin_ctrl.ibhr_por_en) {
+  switch (pin_ctrl.ibhr_por_en)
+  {
     case LSM6DSV16X_SW_RST_DYN_ADDRESS_RST:
       *val = LSM6DSV16X_SW_RST_DYN_ADDRESS_RST;
       break;
@@ -7677,14 +7596,15 @@ int32_t lsm6dsv16x_i3c_reset_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_i3c_ibi_time_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_ibi_time_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_i3c_ibi_time_t val)
 {
   lsm6dsv16x_ctrl5_t ctrl5;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL5, (uint8_t *)&ctrl5, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ctrl5.bus_act_sel = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_CTRL5, (uint8_t *)&ctrl5, 1);
   }
@@ -7700,18 +7620,17 @@ int32_t lsm6dsv16x_i3c_ibi_time_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_i3c_ibi_time_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_ibi_time_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_i3c_ibi_time_t *val)
 {
   lsm6dsv16x_ctrl5_t ctrl5;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_CTRL5, (uint8_t *)&ctrl5, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ctrl5.bus_act_sel) {
+  switch (ctrl5.bus_act_sel)
+  {
     case LSM6DSV16X_IBI_2us:
       *val = LSM6DSV16X_IBI_2us;
       break;
@@ -7757,14 +7676,15 @@ int32_t lsm6dsv16x_i3c_ibi_time_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_master_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
                                                    uint8_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     if_cfg.shub_pu_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -7780,7 +7700,7 @@ int32_t lsm6dsv16x_sh_master_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_master_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
                                                    uint8_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
@@ -7800,7 +7720,7 @@ int32_t lsm6dsv16x_sh_master_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_read_data_raw_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val,
+int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                         uint8_t len)
 {
   int32_t ret;
@@ -7820,7 +7740,7 @@ int32_t lsm6dsv16x_sh_read_data_raw_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_slave_connected_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_slave_connected_set(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_sh_slave_connected_t val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -7828,9 +7748,7 @@ int32_t lsm6dsv16x_sh_slave_connected_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   master_config.aux_sens_on = (uint8_t)val & 0x3U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -7849,7 +7767,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_slave_connected_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_slave_connected_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_sh_slave_connected_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -7858,11 +7776,10 @@ int32_t lsm6dsv16x_sh_slave_connected_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (master_config.aux_sens_on) {
+  switch (master_config.aux_sens_on)
+  {
     case LSM6DSV16X_SLV_0:
       *val = LSM6DSV16X_SLV_0;
       break;
@@ -7895,16 +7812,14 @@ int32_t lsm6dsv16x_sh_slave_connected_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_master_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sh_master_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   master_config.master_on = val;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -7923,7 +7838,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_master_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -7946,16 +7861,14 @@ int32_t lsm6dsv16x_sh_master_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_pass_through_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   master_config.pass_through_mode = val;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -7974,7 +7887,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_pass_through_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -7997,7 +7910,7 @@ int32_t lsm6dsv16x_sh_pass_through_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_syncro_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -8005,9 +7918,7 @@ int32_t lsm6dsv16x_sh_syncro_mode_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   master_config.start_config = (uint8_t)val & 0x01U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -8026,7 +7937,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_syncro_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -8035,11 +7946,10 @@ int32_t lsm6dsv16x_sh_syncro_mode_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (master_config.start_config) {
+  switch (master_config.start_config)
+  {
     case LSM6DSV16X_SH_TRG_XL_GY_DRDY:
       *val = LSM6DSV16X_SH_TRG_XL_GY_DRDY;
       break;
@@ -8064,7 +7974,7 @@ int32_t lsm6dsv16x_sh_syncro_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_write_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_write_mode_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_sh_write_mode_t val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -8072,9 +7982,7 @@ int32_t lsm6dsv16x_sh_write_mode_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   master_config.write_once = (uint8_t)val & 0x01U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -8093,7 +8001,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_write_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_sh_write_mode_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
@@ -8102,11 +8010,10 @@ int32_t lsm6dsv16x_sh_write_mode_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (master_config.write_once) {
+  switch (master_config.write_once)
+  {
     case LSM6DSV16X_EACH_SH_CYCLE:
       *val = LSM6DSV16X_EACH_SH_CYCLE;
       break;
@@ -8131,16 +8038,14 @@ int32_t lsm6dsv16x_sh_write_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_reset_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   master_config.rst_master_regs = val;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_MASTER_CONFIG, (uint8_t *)&master_config, 1);
@@ -8159,7 +8064,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_reset_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_master_config_t master_config;
   int32_t ret;
@@ -8185,29 +8090,23 @@ int32_t lsm6dsv16x_sh_reset_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_cfg_write(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_cfg_write(stmdev_ctx_t *ctx,
                                 lsm6dsv16x_sh_cfg_write_t *val)
 {
   lsm6dsv16x_slv0_add_t reg;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   reg.slave0_add = val->slv0_add;
   reg.rw_0 = 0;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD, (uint8_t *)&reg, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD,
                              &(val->slv0_subadd), 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_DATAWRITE_SLV0,
                              &(val->slv0_data), 1);
@@ -8226,7 +8125,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_data_rate_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t val)
 {
   lsm6dsv16x_slv0_config_t slv0_config;
@@ -8234,9 +8133,7 @@ int32_t lsm6dsv16x_sh_data_rate_set(lsm6dsv16x_ctx_t *ctx,
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   slv0_config.shub_odr = (uint8_t)val & 0x07U;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
@@ -8255,7 +8152,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t *val)
 {
   lsm6dsv16x_slv0_config_t slv0_config;
@@ -8264,11 +8161,10 @@ int32_t lsm6dsv16x_sh_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG, (uint8_t *)&slv0_config, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (slv0_config.shub_odr) {
+  switch (slv0_config.shub_odr)
+  {
     case LSM6DSV16X_SH_15Hz:
       *val = LSM6DSV16X_SH_15Hz;
       break;
@@ -8312,7 +8208,7 @@ int32_t lsm6dsv16x_sh_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_slv_cfg_read(lsm6dsv16x_ctx_t *ctx, uint8_t idx,
+int32_t lsm6dsv16x_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
                                    lsm6dsv16x_sh_cfg_read_t *val)
 {
   lsm6dsv16x_slv0_add_t slv_add;
@@ -8320,32 +8216,24 @@ int32_t lsm6dsv16x_sh_slv_cfg_read(lsm6dsv16x_ctx_t *ctx, uint8_t idx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_SENSOR_HUB_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   slv_add.slave0_add = val->slv_add;
   slv_add.rw_0 = 1;
-  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD + idx * 3U,
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_ADD + idx*3U,
                              (uint8_t *)&slv_add, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
-  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD + idx * 3U,
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_SUBADD + idx*3U,
                              &(val->slv_subadd), 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
-  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U,
+  ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U,
                             (uint8_t *)&slv_config, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   slv_config.slave0_numop = val->slv_len;
-  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx * 3U,
+  ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SLV0_CONFIG + idx*3U,
                              (uint8_t *)&slv_config, 1);
 
 exit:
@@ -8362,7 +8250,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sh_status_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_status_get(stmdev_ctx_t *ctx,
                                  lsm6dsv16x_status_master_t *val)
 {
   int32_t ret;
@@ -8393,13 +8281,14 @@ int32_t lsm6dsv16x_sh_status_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_sdo_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     pin_ctrl.sdo_pu_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_PIN_CTRL, (uint8_t *)&pin_ctrl, 1);
   }
@@ -8415,7 +8304,7 @@ int32_t lsm6dsv16x_ui_sdo_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_sdo_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ui_sdo_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_pin_ctrl_t pin_ctrl;
   int32_t ret;
@@ -8434,14 +8323,15 @@ int32_t lsm6dsv16x_ui_sdo_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     if_cfg.i2c_i3c_disable = (uint8_t)val & 0x1U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -8457,18 +8347,17 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (if_cfg.i2c_i3c_disable) {
+  switch (if_cfg.i2c_i3c_disable)
+  {
     case LSM6DSV16X_I2C_I3C_ENABLE:
       *val = LSM6DSV16X_I2C_I3C_ENABLE;
       break;
@@ -8493,13 +8382,14 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_spi_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t val)
+int32_t lsm6dsv16x_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     if_cfg.sim = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -8515,17 +8405,16 @@ int32_t lsm6dsv16x_spi_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_spi_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val)
+int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (if_cfg.sim) {
+  switch (if_cfg.sim)
+  {
     case LSM6DSV16X_SPI_4_WIRE:
       *val = LSM6DSV16X_SPI_4_WIRE;
       break;
@@ -8550,13 +8439,14 @@ int32_t lsm6dsv16x_spi_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_sda_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_ui_sda_pull_up_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     if_cfg.sda_pu_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_IF_CFG, (uint8_t *)&if_cfg, 1);
   }
@@ -8572,7 +8462,7 @@ int32_t lsm6dsv16x_ui_sda_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_ui_sda_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_ui_sda_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_if_cfg_t if_cfg;
   int32_t ret;
@@ -8584,20 +8474,21 @@ int32_t lsm6dsv16x_ui_sda_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
 }
 
 /**
-  * @brief  SPI2 (OIS interface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = SPI2_CTRL1_OIS).[set]
+  * @brief  SPI2 (OIS Inteface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = SPI2_CTRL1_OIS).[set]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      SPI2_4_WIRE, SPI2_3_WIRE,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_spi2_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val)
+int32_t lsm6dsv16x_spi2_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ui_ctrl1_ois.sim_ois = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
   }
@@ -8606,24 +8497,23 @@ int32_t lsm6dsv16x_spi2_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi2_mode_t v
 }
 
 /**
-  * @brief  SPI2 (OIS interface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = SPI2_CTRL1_OIS).[get]
+  * @brief  SPI2 (OIS Inteface) Serial Interface Mode selection. This function works also on OIS (UI_CTRL1_OIS = SPI2_CTRL1_OIS).[get]
   *
   * @param  ctx      read / write interface definitions
   * @param  val      SPI2_4_WIRE, SPI2_3_WIRE,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_spi2_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *val)
+int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *val)
 {
   lsm6dsv16x_ui_ctrl1_ois_t ui_ctrl1_ois;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_UI_CTRL1_OIS, (uint8_t *)&ui_ctrl1_ois, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (ui_ctrl1_ois.sim_ois) {
+  switch (ui_ctrl1_ois.sim_ois)
+  {
     case LSM6DSV16X_SPI2_4_WIRE:
       *val = LSM6DSV16X_SPI2_4_WIRE;
       break;
@@ -8662,15 +8552,13 @@ int32_t lsm6dsv16x_spi2_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi2_mode_t *
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sigmot_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   emb_func_en_a.sign_motion_en = val;
@@ -8689,15 +8577,13 @@ int32_t lsm6dsv16x_sigmot_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sigmot_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.sign_motion_en;
@@ -8727,7 +8613,7 @@ int32_t lsm6dsv16x_sigmot_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_stpcnt_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_stpcnt_mode_t val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
@@ -8736,19 +8622,16 @@ int32_t lsm6dsv16x_stpcnt_mode_set(lsm6dsv16x_ctx_t *ctx,
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_B, (uint8_t *)&emb_func_en_b, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   if ((val.false_step_rej == PROPERTY_ENABLE)
       && ((emb_func_en_a.mlc_before_fsm_en & emb_func_en_b.mlc_en) ==
-          PROPERTY_DISABLE)) {
+          PROPERTY_DISABLE))
+  {
     emb_func_en_a.mlc_before_fsm_en = PROPERTY_ENABLE;
   }
 
@@ -8758,7 +8641,8 @@ int32_t lsm6dsv16x_stpcnt_mode_set(lsm6dsv16x_ctx_t *ctx,
 exit:
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
     pedo_cmd_reg.fp_rejection_en = val.false_step_rej;
     ret += lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
@@ -8775,7 +8659,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_stpcnt_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_stpcnt_mode_t *val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
@@ -8785,14 +8669,10 @@ int32_t lsm6dsv16x_stpcnt_mode_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_CMD_REG, (uint8_t *)&pedo_cmd_reg, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->false_step_rej = pedo_cmd_reg.fp_rejection_en;
   val->step_counter_enable = emb_func_en_a.pedo_en;
@@ -8808,7 +8688,7 @@ int32_t lsm6dsv16x_stpcnt_mode_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_steps_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_stpcnt_steps_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -8816,9 +8696,7 @@ int32_t lsm6dsv16x_stpcnt_steps_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_STEP_COUNTER_L, &buff[0], 2);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -8834,20 +8712,16 @@ int32_t lsm6dsv16x_stpcnt_steps_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_rst_step_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_stpcnt_rst_step_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_src_t emb_func_src;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   emb_func_src.pedo_rst_step = val;
   ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
@@ -8866,15 +8740,13 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_rst_step_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_stpcnt_rst_step_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_src_t emb_func_src;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_SRC, (uint8_t *)&emb_func_src, 1);
   *val = emb_func_src.pedo_rst_step;
@@ -8892,13 +8764,14 @@ int32_t lsm6dsv16x_stpcnt_rst_step_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_debounce_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_stpcnt_debounce_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_pedo_deb_steps_conf_t pedo_deb_steps_conf;
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_DEB_STEPS_CONF, (uint8_t *)&pedo_deb_steps_conf, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     pedo_deb_steps_conf.deb_step = val;
     ret = lsm6dsv16x_ln_pg_write(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_DEB_STEPS_CONF, (uint8_t *)&pedo_deb_steps_conf, 1);
   }
@@ -8914,7 +8787,7 @@ int32_t lsm6dsv16x_stpcnt_debounce_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_debounce_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_stpcnt_debounce_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_pedo_deb_steps_conf_t pedo_deb_steps_conf;
   int32_t ret;
@@ -8933,7 +8806,7 @@ int32_t lsm6dsv16x_stpcnt_debounce_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_period_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
+int32_t lsm6dsv16x_stpcnt_period_set(stmdev_ctx_t *ctx, uint16_t val)
 {
   uint8_t buff[2];
   int32_t ret;
@@ -8953,15 +8826,13 @@ int32_t lsm6dsv16x_stpcnt_period_set(lsm6dsv16x_ctx_t *ctx, uint16_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_stpcnt_period_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
+int32_t lsm6dsv16x_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val)
 {
   uint8_t buff[2];
   int32_t ret;
 
   ret = lsm6dsv16x_ln_pg_read(ctx, LSM6DSV16X_EMB_ADV_PG_1 + LSM6DSV16X_PEDO_SC_DELTAT_L, &buff[0], 2);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[1];
   *val = (*val * 256U) + buff[0];
@@ -8989,20 +8860,16 @@ int32_t lsm6dsv16x_stpcnt_period_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_game_rotation_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   emb_func_en_a.sflp_game_en = val;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A,
@@ -9022,15 +8889,13 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_game_rotation_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.sflp_game_en;
@@ -9048,21 +8913,17 @@ int32_t lsm6dsv16x_sflp_game_rotation_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_data_rate_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t val)
 {
   lsm6dsv16x_sflp_odr_t sflp_odr;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
-  if (ret != 0) {
-    goto exit;
-  }
+  if (ret != 0) { goto exit; }
 
   sflp_odr.sflp_game_odr = (uint8_t)val & 0x07U;
   ret += lsm6dsv16x_write_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
@@ -9081,7 +8942,7 @@ exit:
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_sflp_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t *val)
 {
   lsm6dsv16x_sflp_odr_t sflp_odr;
@@ -9090,11 +8951,10 @@ int32_t lsm6dsv16x_sflp_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_SFLP_ODR, (uint8_t *)&sflp_odr, 1);
   ret += lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_MAIN_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (sflp_odr.sflp_game_odr) {
+  switch (sflp_odr.sflp_game_odr)
+  {
     case LSM6DSV16X_SFLP_15Hz:
       *val = LSM6DSV16X_SFLP_15Hz;
       break;
@@ -9148,14 +9008,15 @@ int32_t lsm6dsv16x_sflp_data_rate_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_detection_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_detection_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     tap_cfg0.tap_x_en = val.tap_x_en;
     tap_cfg0.tap_y_en = val.tap_y_en;
     tap_cfg0.tap_z_en = val.tap_z_en;
@@ -9173,16 +9034,14 @@ int32_t lsm6dsv16x_tap_detection_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_detection_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_detection_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t *val)
 {
   lsm6dsv16x_tap_cfg0_t tap_cfg0;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG0, (uint8_t *)&tap_cfg0, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->tap_x_en = tap_cfg0.tap_x_en;
   val->tap_y_en = tap_cfg0.tap_y_en;
@@ -9199,7 +9058,7 @@ int32_t lsm6dsv16x_tap_detection_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_thresholds_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_thresholds_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
@@ -9210,9 +9069,7 @@ int32_t lsm6dsv16x_tap_thresholds_set(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   tap_cfg1.tap_ths_x = val.x;
   tap_cfg2.tap_ths_y = val.y;
@@ -9233,7 +9090,7 @@ int32_t lsm6dsv16x_tap_thresholds_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_thresholds_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_thresholds_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t *val)
 {
   lsm6dsv16x_tap_ths_6d_t tap_ths_6d;
@@ -9244,9 +9101,7 @@ int32_t lsm6dsv16x_tap_thresholds_get(lsm6dsv16x_ctx_t *ctx,
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG2, (uint8_t *)&tap_cfg2, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_THS_6D, (uint8_t *)&tap_ths_6d, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->x  = tap_cfg1.tap_ths_x;
   val->y = tap_cfg2.tap_ths_y;
@@ -9263,14 +9118,15 @@ int32_t lsm6dsv16x_tap_thresholds_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_axis_priority_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_axis_priority_set(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t val)
 {
   lsm6dsv16x_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     tap_cfg1.tap_priority = (uint8_t)val & 0x7U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
   }
@@ -9286,18 +9142,17 @@ int32_t lsm6dsv16x_tap_axis_priority_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_axis_priority_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t *val)
 {
   lsm6dsv16x_tap_cfg1_t tap_cfg1;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_CFG1, (uint8_t *)&tap_cfg1, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (tap_cfg1.tap_priority) {
+  switch (tap_cfg1.tap_priority)
+  {
     case LSM6DSV16X_XYZ :
       *val = LSM6DSV16X_XYZ ;
       break;
@@ -9338,14 +9193,15 @@ int32_t lsm6dsv16x_tap_axis_priority_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_time_windows_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_time_windows_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t val)
 {
   lsm6dsv16x_tap_dur_t tap_dur;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_DUR, (uint8_t *)&tap_dur, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     tap_dur.shock = val.shock;
     tap_dur.quiet = val.quiet;
     tap_dur.dur = val.tap_gap;
@@ -9363,16 +9219,14 @@ int32_t lsm6dsv16x_tap_time_windows_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_time_windows_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_time_windows_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t *val)
 {
   lsm6dsv16x_tap_dur_t tap_dur;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TAP_DUR, (uint8_t *)&tap_dur, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->shock = tap_dur.shock;
   val->quiet = tap_dur.quiet;
@@ -9389,13 +9243,14 @@ int32_t lsm6dsv16x_tap_time_windows_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t val)
+int32_t lsm6dsv16x_tap_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t val)
 {
   lsm6dsv16x_wake_up_ths_t wake_up_ths;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     wake_up_ths.single_double_tap = (uint8_t)val & 0x01U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   }
@@ -9411,17 +9266,16 @@ int32_t lsm6dsv16x_tap_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tap_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val)
+int32_t lsm6dsv16x_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val)
 {
   lsm6dsv16x_wake_up_ths_t wake_up_ths;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (wake_up_ths.single_double_tap) {
+  switch (wake_up_ths.single_double_tap)
+  {
     case LSM6DSV16X_ONLY_SINGLE:
       *val = LSM6DSV16X_ONLY_SINGLE;
       break;
@@ -9459,15 +9313,13 @@ int32_t lsm6dsv16x_tap_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tilt_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_tilt_mode_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   emb_func_en_a.tilt_en = val;
@@ -9486,15 +9338,13 @@ int32_t lsm6dsv16x_tilt_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_tilt_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_tilt_mode_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_emb_func_en_a_t emb_func_en_a;
   int32_t ret;
 
   ret = lsm6dsv16x_mem_bank_set(ctx, LSM6DSV16X_EMBED_FUNC_MEM_BANK);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_EMB_FUNC_EN_A, (uint8_t *)&emb_func_en_a, 1);
   *val = emb_func_en_a.tilt_en;
@@ -9525,15 +9375,13 @@ int32_t lsm6dsv16x_tilt_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_timestamp_raw_get(lsm6dsv16x_ctx_t *ctx, uint32_t *val)
+int32_t lsm6dsv16x_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val)
 {
   uint8_t buff[4];
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_TIMESTAMP0, &buff[0], 4);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   *val = buff[3];
   *val = (*val * 256U) + buff[2];
@@ -9551,13 +9399,14 @@ int32_t lsm6dsv16x_timestamp_raw_get(lsm6dsv16x_ctx_t *ctx, uint32_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_timestamp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
+int32_t lsm6dsv16x_timestamp_set(stmdev_ctx_t *ctx, uint8_t val)
 {
   lsm6dsv16x_functions_enable_t functions_enable;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     functions_enable.timestamp_en = val;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   }
@@ -9573,7 +9422,7 @@ int32_t lsm6dsv16x_timestamp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_timestamp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
+int32_t lsm6dsv16x_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
 {
   lsm6dsv16x_functions_enable_t functions_enable;
   int32_t ret;
@@ -9605,13 +9454,14 @@ int32_t lsm6dsv16x_timestamp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t val)
+int32_t lsm6dsv16x_act_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t val)
 {
   lsm6dsv16x_functions_enable_t functions_enable;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     functions_enable.inact_en = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
   }
@@ -9627,17 +9477,16 @@ int32_t lsm6dsv16x_act_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t val
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t *val)
+int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val)
 {
   lsm6dsv16x_functions_enable_t functions_enable;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_FUNCTIONS_ENABLE, (uint8_t *)&functions_enable, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (functions_enable.inact_en) {
+  switch (functions_enable.inact_en)
+  {
     case LSM6DSV16X_XL_AND_GY_NOT_AFFECTED:
       *val = LSM6DSV16X_XL_AND_GY_NOT_AFFECTED;
       break;
@@ -9670,14 +9519,15 @@ int32_t lsm6dsv16x_act_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t *va
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(stmdev_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     inactivity_dur.inact_dur = (uint8_t)val & 0x3U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
   }
@@ -9693,18 +9543,17 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t *val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (inactivity_dur.inact_dur) {
+  switch (inactivity_dur.inact_dur)
+  {
     case LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE:
       *val = LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE;
       break;
@@ -9737,14 +9586,15 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_sleep_xl_odr_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_sleep_xl_odr_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     inactivity_dur.xl_inact_odr = (uint8_t)val & 0x03U;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
   }
@@ -9760,18 +9610,17 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_sleep_xl_odr_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t *val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_DUR, (uint8_t *)&inactivity_dur, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
-  switch (inactivity_dur.xl_inact_odr) {
+  switch (inactivity_dur.xl_inact_odr)
+  {
     case LSM6DSV16X_1Hz875:
       *val = LSM6DSV16X_1Hz875;
       break;
@@ -9804,7 +9653,7 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_thresholds_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_thresholds_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val)
 {
   lsm6dsv16x_inactivity_ths_t inactivity_ths;
@@ -9817,9 +9666,7 @@ int32_t lsm6dsv16x_act_thresholds_set(lsm6dsv16x_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   inactivity_dur.wu_inact_ths_w = val->inactivity_cfg.wu_inact_ths_w;
   inactivity_dur.xl_inact_odr = val->inactivity_cfg.xl_inact_odr;
@@ -9845,7 +9692,7 @@ int32_t lsm6dsv16x_act_thresholds_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_thresholds_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_thresholds_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val)
 {
   lsm6dsv16x_inactivity_dur_t inactivity_dur;
@@ -9858,9 +9705,7 @@ int32_t lsm6dsv16x_act_thresholds_get(lsm6dsv16x_ctx_t *ctx,
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_INACTIVITY_THS, (uint8_t *)&inactivity_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_THS, (uint8_t *)&wake_up_ths, 1);
   ret += lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->inactivity_cfg.wu_inact_ths_w = inactivity_dur.wu_inact_ths_w;
   val->inactivity_cfg.xl_inact_odr = inactivity_dur.xl_inact_odr;
@@ -9881,14 +9726,15 @@ int32_t lsm6dsv16x_act_thresholds_get(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_wkup_time_windows_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_wkup_time_windows_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_act_wkup_time_windows_t val)
 {
   lsm6dsv16x_wake_up_dur_t wake_up_dur;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret == 0) {
+  if (ret == 0)
+  {
     wake_up_dur.wake_dur = val.shock;
     wake_up_dur.sleep_dur = val.quiet;
     ret = lsm6dsv16x_write_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
@@ -9905,16 +9751,14 @@ int32_t lsm6dsv16x_act_wkup_time_windows_set(lsm6dsv16x_ctx_t *ctx,
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
-int32_t lsm6dsv16x_act_wkup_time_windows_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_wkup_time_windows_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_act_wkup_time_windows_t *val)
 {
   lsm6dsv16x_wake_up_dur_t wake_up_dur;
   int32_t ret;
 
   ret = lsm6dsv16x_read_reg(ctx, LSM6DSV16X_WAKE_UP_DUR, (uint8_t *)&wake_up_dur, 1);
-  if (ret != 0) {
-    return ret;
-  }
+  if (ret != 0) { return ret; }
 
   val->shock = wake_up_dur.wake_dur;
   val->quiet = wake_up_dur.sleep_dur;

--- a/src/lsm6dsv16x_reg.h
+++ b/src/lsm6dsv16x_reg.h
@@ -120,7 +120,7 @@ typedef struct {
   stmdev_mdelay_ptr   mdelay;
   /** Customizable optional pointer **/
   void *handle;
-} stmdev_ctx_t;
+} lsm6dsv16x_ctx_t;
 
 /**
   * @}
@@ -3620,10 +3620,10 @@ typedef union {
  * them with a custom implementation.
  */
 
-int32_t lsm6dsv16x_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
+int32_t lsm6dsv16x_read_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
                             uint8_t *data,
                             uint16_t len);
-int32_t lsm6dsv16x_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
+int32_t lsm6dsv16x_write_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
                              uint8_t *data,
                              uint16_t len);
 
@@ -3646,17 +3646,17 @@ float_t lsm6dsv16x_from_lsb_to_nsec(uint32_t lsb);
 
 float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb);
 
-int32_t lsm6dsv16x_xl_offset_on_out_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_xl_offset_on_out_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_xl_offset_on_out_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_xl_offset_on_out_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   float_t z_mg;
   float_t y_mg;
   float_t x_mg;
 } lsm6dsv16x_xl_offset_mg_t;
-int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_offset_mg_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t val);
-int32_t lsm6dsv16x_xl_offset_mg_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_offset_mg_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t *val);
 
 typedef enum {
@@ -3665,18 +3665,18 @@ typedef enum {
   LSM6DSV16X_RESTORE_CAL_PARAM = 0x2,
   LSM6DSV16X_RESTORE_CTRL_REGS = 0x4,
 } lsm6dsv16x_reset_t;
-int32_t lsm6dsv16x_reset_set(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val);
-int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val);
+int32_t lsm6dsv16x_reset_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t val);
+int32_t lsm6dsv16x_reset_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t *val);
 
 typedef enum {
   LSM6DSV16X_MAIN_MEM_BANK       = 0x0,
   LSM6DSV16X_EMBED_FUNC_MEM_BANK = 0x1,
   LSM6DSV16X_SENSOR_HUB_MEM_BANK = 0x2,
 } lsm6dsv16x_mem_bank_t;
-int32_t lsm6dsv16x_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t val);
-int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val);
+int32_t lsm6dsv16x_mem_bank_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t val);
+int32_t lsm6dsv16x_mem_bank_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val);
 
-int32_t lsm6dsv16x_device_id_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_device_id_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_ODR_OFF              = 0x0,
@@ -3713,13 +3713,13 @@ typedef enum {
   LSM6DSV16X_ODR_HA02_AT_3200Hz   = 0x2B,
   LSM6DSV16X_ODR_HA02_AT_6400Hz   = 0x2C,
 } lsm6dsv16x_data_rate_t;
-int32_t lsm6dsv16x_xl_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t val);
-int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val);
-int32_t lsm6dsv16x_gy_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t val);
-int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val);
 
 
@@ -3732,8 +3732,8 @@ typedef enum {
   LSM6DSV16X_XL_LOW_POWER_8_AVG_MD    = 0x6,
   LSM6DSV16X_XL_NORMAL_MD             = 0x7,
 } lsm6dsv16x_xl_mode_t;
-int32_t lsm6dsv16x_xl_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t val);
-int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val);
+int32_t lsm6dsv16x_xl_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t val);
+int32_t lsm6dsv16x_xl_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val);
 
 typedef enum {
   LSM6DSV16X_GY_HIGH_PERFORMANCE_MD   = 0x0,
@@ -3741,34 +3741,34 @@ typedef enum {
   LSM6DSV16X_GY_SLEEP_MD              = 0x4,
   LSM6DSV16X_GY_LOW_POWER_MD          = 0x5,
 } lsm6dsv16x_gy_mode_t;
-int32_t lsm6dsv16x_gy_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t val);
-int32_t lsm6dsv16x_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val);
+int32_t lsm6dsv16x_gy_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t val);
+int32_t lsm6dsv16x_gy_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val);
 
-int32_t lsm6dsv16x_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_auto_increment_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_auto_increment_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_block_data_update_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_block_data_update_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_odr_trig_cfg_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_odr_trig_cfg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_odr_trig_cfg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_DRDY_LATCHED = 0x0,
   LSM6DSV16X_DRDY_PULSED  = 0x1,
 } lsm6dsv16x_data_ready_mode_t;
-int32_t lsm6dsv16x_data_ready_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_data_ready_mode_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t val);
-int32_t lsm6dsv16x_data_ready_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_data_ready_mode_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t *val);
 
 typedef struct {
   uint8_t enable               : 1; /* interrupt enable */
   uint8_t lir                  : 1; /* interrupt pulsed or latched */
 } lsm6dsv16x_interrupt_mode_t;
-int32_t lsm6dsv16x_interrupt_enable_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_interrupt_enable_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t val);
-int32_t lsm6dsv16x_interrupt_enable_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_interrupt_enable_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t *val);
 
 typedef enum {
@@ -3779,9 +3779,9 @@ typedef enum {
   LSM6DSV16X_2000dps = 0x4,
   LSM6DSV16X_4000dps = 0xc,
 } lsm6dsv16x_gy_full_scale_t;
-int32_t lsm6dsv16x_gy_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t val);
-int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t *val);
 
 typedef enum {
@@ -3790,22 +3790,22 @@ typedef enum {
   LSM6DSV16X_8g  = 0x2,
   LSM6DSV16X_16g = 0x3,
 } lsm6dsv16x_xl_full_scale_t;
-int32_t lsm6dsv16x_xl_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_xl_full_scale_t val);
-int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_xl_full_scale_t *val);
 
-int32_t lsm6dsv16x_xl_dual_channel_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_xl_dual_channel_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_xl_dual_channel_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_xl_dual_channel_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_XL_ST_DISABLE  = 0x0,
   LSM6DSV16X_XL_ST_POSITIVE = 0x1,
   LSM6DSV16X_XL_ST_NEGATIVE = 0x2,
 } lsm6dsv16x_xl_self_test_t;
-int32_t lsm6dsv16x_xl_self_test_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t val);
-int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t *val);
 
 typedef enum {
@@ -3813,9 +3813,9 @@ typedef enum {
   LSM6DSV16X_OIS_XL_ST_POSITIVE = 0x1,
   LSM6DSV16X_OIS_XL_ST_NEGATIVE = 0x2,
 } lsm6dsv16x_ois_xl_self_test_t;
-int32_t lsm6dsv16x_ois_xl_self_test_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t val);
-int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t *val);
 
 typedef enum {
@@ -3824,9 +3824,9 @@ typedef enum {
   LSM6DSV16X_GY_ST_NEGATIVE = 0x2,
 
 } lsm6dsv16x_gy_self_test_t;
-int32_t lsm6dsv16x_gy_self_test_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t val);
-int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t *val);
 
 typedef enum {
@@ -3837,9 +3837,9 @@ typedef enum {
   LSM6DSV16X_OIS_GY_ST_CLAMP_NEG = 0x6,
 
 } lsm6dsv16x_ois_gy_self_test_t;
-int32_t lsm6dsv16x_ois_gy_self_test_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t val);
-int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t *val);
 
 typedef struct {
@@ -3903,7 +3903,7 @@ typedef struct {
   uint8_t fifo_ovr             : 1;
   uint8_t fifo_th              : 1;
 } lsm6dsv16x_all_sources_t;
-int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_all_sources_t *val);
 
 typedef struct {
@@ -3925,13 +3925,13 @@ typedef struct {
   uint8_t freefall             : 1;
   uint8_t sleep_change         : 1;
 } lsm6dsv16x_pin_int_route_t;
-int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int1_route_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
-int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int1_route_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
-int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int2_route_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
-int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int2_route_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
 
 typedef struct {
@@ -3939,47 +3939,47 @@ typedef struct {
   uint8_t drdy_gy              : 1;
   uint8_t drdy_temp            : 1;
 } lsm6dsv16x_data_ready_t;
-int32_t lsm6dsv16x_flag_data_ready_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_flag_data_ready_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_t *val);
 
-int32_t lsm6dsv16x_int_ack_mask_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_int_ack_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_int_ack_mask_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_int_ack_mask_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_temperature_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_ois_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx,
                                                 int16_t *val);
 
-int32_t lsm6dsv16x_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_dual_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_dual_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_ois_dual_acceleration_raw_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_dual_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx,
                                                  int16_t *val);
 
-int32_t lsm6dsv16x_ah_qvar_raw_get(stmdev_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_ah_qvar_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_odr_cal_reg_get(stmdev_ctx_t *ctx, int8_t *val);
+int32_t lsm6dsv16x_odr_cal_reg_get(lsm6dsv16x_ctx_t *ctx, int8_t *val);
 
-int32_t lsm6dsv16x_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
+int32_t lsm6dsv16x_ln_pg_write(lsm6dsv16x_ctx_t *ctx, uint16_t address,
                                uint8_t *buf, uint8_t len);
-int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
+int32_t lsm6dsv16x_ln_pg_read(lsm6dsv16x_ctx_t *ctx, uint16_t address, uint8_t *buf,
                               uint8_t len);
 
-int32_t lsm6dsv16x_emb_function_dbg_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_emb_function_dbg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_emb_function_dbg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_DEN_ACT_LOW  = 0x0,
   LSM6DSV16X_DEN_ACT_HIGH = 0x1,
 } lsm6dsv16x_den_polarity_t;
-int32_t lsm6dsv16x_den_polarity_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_den_polarity_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t val);
-int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_den_polarity_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t *val);
 
 typedef struct {
@@ -3994,8 +3994,8 @@ typedef struct {
     LEVEL_LATCHED   = 0x03,
   } mode;
 } lsm6dsv16x_den_conf_t;
-int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val);
-int32_t lsm6dsv16x_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t *val);
+int32_t lsm6dsv16x_den_conf_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t val);
+int32_t lsm6dsv16x_den_conf_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t *val);
 
 typedef enum {
   LSM6DSV16X_EIS_125dps  = 0x0,
@@ -4004,29 +4004,29 @@ typedef enum {
   LSM6DSV16X_EIS_1000dps = 0x3,
   LSM6DSV16X_EIS_2000dps = 0x4,
 } lsm6dsv16x_eis_gy_full_scale_t;
-int32_t lsm6dsv16x_eis_gy_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_eis_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_eis_gy_full_scale_t val);
-int32_t lsm6dsv16x_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_eis_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_eis_gy_full_scale_t *val);
 
-int32_t lsm6dsv16x_eis_gy_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_eis_gy_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_eis_gy_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_eis_gy_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_EIS_ODR_OFF = 0x0,
   LSM6DSV16X_EIS_1920Hz  = 0x1,
   LSM6DSV16X_EIS_960Hz   = 0x2,
 } lsm6dsv16x_gy_eis_data_rate_t;
-int32_t lsm6dsv16x_gy_eis_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_eis_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_gy_eis_data_rate_t val);
-int32_t lsm6dsv16x_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_eis_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_gy_eis_data_rate_t *val);
 
-int32_t lsm6dsv16x_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_watermark_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_watermark_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_CMP_DISABLE = 0x0,
@@ -4034,23 +4034,23 @@ typedef enum {
   LSM6DSV16X_CMP_16_TO_1 = 0x2,
   LSM6DSV16X_CMP_32_TO_1 = 0x3,
 } lsm6dsv16x_fifo_compress_algo_t;
-int32_t lsm6dsv16x_fifo_compress_algo_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_set(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_fifo_compress_algo_t val);
-int32_t lsm6dsv16x_fifo_compress_algo_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_get(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_fifo_compress_algo_t *val);
 
-int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(lsm6dsv16x_ctx_t *ctx,
                                                  uint8_t val);
-int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(lsm6dsv16x_ctx_t *ctx,
                                                  uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(lsm6dsv16x_ctx_t *ctx,
                                                     uint8_t val);
-int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(lsm6dsv16x_ctx_t *ctx,
                                                     uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_stop_on_wtm_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_stop_on_wtm_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_XL_NOT_BATCHED       = 0x0,
@@ -4067,9 +4067,9 @@ typedef enum {
   LSM6DSV16X_XL_BATCHED_AT_3840Hz = 0xb,
   LSM6DSV16X_XL_BATCHED_AT_7680Hz = 0xc,
 } lsm6dsv16x_fifo_xl_batch_t;
-int32_t lsm6dsv16x_fifo_xl_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_xl_batch_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t val);
-int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_xl_batch_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t *val);
 
 typedef enum {
@@ -4087,9 +4087,9 @@ typedef enum {
   LSM6DSV16X_GY_BATCHED_AT_3840Hz = 0xb,
   LSM6DSV16X_GY_BATCHED_AT_7680Hz = 0xc,
 } lsm6dsv16x_fifo_gy_batch_t;
-int32_t lsm6dsv16x_fifo_gy_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_gy_batch_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t val);
-int32_t lsm6dsv16x_fifo_gy_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_gy_batch_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t *val);
 
 typedef enum {
@@ -4101,12 +4101,12 @@ typedef enum {
   LSM6DSV16X_STREAM_MODE             = 0x6,
   LSM6DSV16X_BYPASS_TO_FIFO_MODE     = 0x7,
 } lsm6dsv16x_fifo_mode_t;
-int32_t lsm6dsv16x_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val);
-int32_t lsm6dsv16x_fifo_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val);
+int32_t lsm6dsv16x_fifo_mode_get(lsm6dsv16x_ctx_t *ctx,
                                  lsm6dsv16x_fifo_mode_t *val);
 
-int32_t lsm6dsv16x_fifo_gy_eis_batch_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_gy_eis_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_gy_eis_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_gy_eis_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_TEMP_NOT_BATCHED       = 0x0,
@@ -4114,9 +4114,9 @@ typedef enum {
   LSM6DSV16X_TEMP_BATCHED_AT_15Hz   = 0x2,
   LSM6DSV16X_TEMP_BATCHED_AT_60Hz   = 0x3,
 } lsm6dsv16x_fifo_temp_batch_t;
-int32_t lsm6dsv16x_fifo_temp_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_temp_batch_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t val);
-int32_t lsm6dsv16x_fifo_temp_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_temp_batch_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t *val);
 
 typedef enum {
@@ -4125,14 +4125,14 @@ typedef enum {
   LSM6DSV16X_TMSTMP_DEC_8       = 0x2,
   LSM6DSV16X_TMSTMP_DEC_32      = 0x3,
 } lsm6dsv16x_fifo_timestamp_batch_t;
-int32_t lsm6dsv16x_fifo_timestamp_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_timestamp_batch_set(lsm6dsv16x_ctx_t *ctx,
                                             lsm6dsv16x_fifo_timestamp_batch_t val);
-int32_t lsm6dsv16x_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_timestamp_batch_get(lsm6dsv16x_ctx_t *ctx,
                                             lsm6dsv16x_fifo_timestamp_batch_t *val);
 
-int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(lsm6dsv16x_ctx_t *ctx,
                                                     uint16_t val);
-int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(lsm6dsv16x_ctx_t *ctx,
                                                     uint16_t *val);
 
 typedef enum {
@@ -4140,9 +4140,9 @@ typedef enum {
   LSM6DSV16X_GY_BATCH_EVENT     = 0x1,
   LSM6DSV16X_GY_EIS_BATCH_EVENT = 0x2,
 } lsm6dsv16x_fifo_batch_cnt_event_t;
-int32_t lsm6dsv16x_fifo_batch_cnt_event_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_cnt_event_set(lsm6dsv16x_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t val);
-int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_cnt_event_get(lsm6dsv16x_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t *val);
 
 typedef struct {
@@ -4153,7 +4153,7 @@ typedef struct {
   uint8_t fifo_th              : 1;
 } lsm6dsv16x_fifo_status_t;
 
-int32_t lsm6dsv16x_fifo_status_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_status_get(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_fifo_status_t *val);
 
 typedef struct {
@@ -4190,38 +4190,38 @@ typedef struct {
   uint8_t cnt;
   uint8_t data[6];
 } lsm6dsv16x_fifo_out_raw_t;
-int32_t lsm6dsv16x_fifo_out_raw_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_out_raw_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_fifo_out_raw_t *val);
 
-int32_t lsm6dsv16x_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_stpcnt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_stpcnt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_mlc_batch_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_mlc_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_mlc_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_mlc_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val);
-int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_sh_batch_slave_set(lsm6dsv16x_ctx_t *ctx, uint8_t idx, uint8_t val);
+int32_t lsm6dsv16x_fifo_sh_batch_slave_get(lsm6dsv16x_ctx_t *ctx, uint8_t idx, uint8_t *val);
 
 typedef struct {
   uint8_t game_rotation        : 1;
   uint8_t gravity              : 1;
   uint8_t gbias                : 1;
 } lsm6dsv16x_fifo_sflp_raw_t;
-int32_t lsm6dsv16x_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_sflp_batch_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t val);
-int32_t lsm6dsv16x_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_sflp_batch_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t *val);
 
 typedef enum {
   LSM6DSV16X_AUTO          = 0x0,
   LSM6DSV16X_ALWAYS_ACTIVE = 0x1,
 } lsm6dsv16x_filt_anti_spike_t;
-int32_t lsm6dsv16x_filt_anti_spike_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_anti_spike_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t val);
-int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_anti_spike_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t *val);
 
 typedef struct {
@@ -4230,17 +4230,17 @@ typedef struct {
   uint8_t irq_xl               : 1;
   uint8_t irq_g                : 1;
 } lsm6dsv16x_filt_settling_mask_t;
-int32_t lsm6dsv16x_filt_settling_mask_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t val);
-int32_t lsm6dsv16x_filt_settling_mask_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t *val);
 
 typedef struct {
   uint8_t ois_drdy             : 1;
 } lsm6dsv16x_filt_ois_settling_mask_t;
-int32_t lsm6dsv16x_filt_ois_settling_mask_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_ois_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t val);
-int32_t lsm6dsv16x_filt_ois_settling_mask_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_ois_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t *val);
 
 typedef enum {
@@ -4253,13 +4253,13 @@ typedef enum {
   LSM6DSV16X_GY_AGGRESSIVE    = 0x6,
   LSM6DSV16X_GY_XTREME        = 0x7,
 } lsm6dsv16x_filt_gy_lp1_bandwidth_t;
-int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_filt_gy_lp1_bandwidth_t val);
-int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_filt_gy_lp1_bandwidth_t *val);
 
-int32_t lsm6dsv16x_filt_gy_lp1_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_filt_gy_lp1_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_filt_gy_lp1_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_filt_gy_lp1_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_XL_ULTRA_LIGHT = 0x0,
@@ -4271,27 +4271,27 @@ typedef enum {
   LSM6DSV16X_XL_AGGRESSIVE  = 0x6,
   LSM6DSV16X_XL_XTREME      = 0x7,
 } lsm6dsv16x_filt_xl_lp2_bandwidth_t;
-int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_filt_xl_lp2_bandwidth_t val);
-int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_filt_xl_lp2_bandwidth_t *val);
 
-int32_t lsm6dsv16x_filt_xl_lp2_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_filt_xl_lp2_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_filt_xl_lp2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_filt_xl_lp2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_filt_xl_hp_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_filt_xl_hp_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_filt_xl_hp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_filt_xl_hp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_filt_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_filt_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_filt_xl_fast_settling_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_filt_xl_fast_settling_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_HP_MD_NORMAL    = 0x0,
   LSM6DSV16X_HP_MD_REFERENCE = 0x1,
 } lsm6dsv16x_filt_xl_hp_mode_t;
-int32_t lsm6dsv16x_filt_xl_hp_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_hp_mode_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t val);
-int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_hp_mode_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t *val);
 
 typedef enum {
@@ -4299,30 +4299,30 @@ typedef enum {
   LSM6DSV16X_WK_FEED_HIGH_PASS      = 0x1,
   LSM6DSV16X_WK_FEED_LP_WITH_OFFSET = 0x2,
 } lsm6dsv16x_filt_wkup_act_feed_t;
-int32_t lsm6dsv16x_filt_wkup_act_feed_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_wkup_act_feed_set(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_filt_wkup_act_feed_t val);
-int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_wkup_act_feed_get(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_filt_wkup_act_feed_t *val);
 
-int32_t lsm6dsv16x_mask_trigger_xl_settl_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_mask_trigger_xl_settl_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_mask_trigger_xl_settl_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_mask_trigger_xl_settl_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_SIXD_FEED_ODR_DIV_2 = 0x0,
   LSM6DSV16X_SIXD_FEED_LOW_PASS  = 0x1,
 } lsm6dsv16x_filt_sixd_feed_t;
-int32_t lsm6dsv16x_filt_sixd_feed_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_sixd_feed_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t val);
-int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_sixd_feed_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t *val);
 
 typedef enum {
   LSM6DSV16X_EIS_LP_NORMAL = 0x0,
   LSM6DSV16X_EIS_LP_LIGHT  = 0x1,
 } lsm6dsv16x_filt_gy_eis_lp_bandwidth_t;
-int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t val);
-int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t *val);
 
 typedef enum {
@@ -4331,9 +4331,9 @@ typedef enum {
   LSM6DSV16X_OIS_GY_LP_AGGRESSIVE = 0x2,
   LSM6DSV16X_OIS_GY_LP_LIGHT      = 0x3,
 } lsm6dsv16x_filt_gy_ois_lp_bandwidth_t;
-int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t val);
-int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t *val);
 
 typedef enum {
@@ -4346,20 +4346,20 @@ typedef enum {
   LSM6DSV16X_OIS_XL_LP_AGGRESSIVE  = 0x6,
   LSM6DSV16X_OIS_XL_LP_XTREME      = 0x7,
 } lsm6dsv16x_filt_xl_ois_lp_bandwidth_t;
-int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t val);
-int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t *val);
 
 typedef enum {
   LSM6DSV16X_PROTECT_CTRL_REGS = 0x0,
   LSM6DSV16X_WRITE_CTRL_REG    = 0x1,
 } lsm6dsv16x_fsm_permission_t;
-int32_t lsm6dsv16x_fsm_permission_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_permission_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t val);
-int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_permission_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t *val);
-int32_t lsm6dsv16x_fsm_permission_status(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fsm_permission_status(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t fsm1_en              : 1;
@@ -4371,11 +4371,11 @@ typedef struct {
   uint8_t fsm7_en              : 1;
   uint8_t fsm8_en              : 1;
 } lsm6dsv16x_fsm_mode_t;
-int32_t lsm6dsv16x_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val);
-int32_t lsm6dsv16x_fsm_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val);
+int32_t lsm6dsv16x_fsm_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val);
+int32_t lsm6dsv16x_fsm_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val);
 
-int32_t lsm6dsv16x_fsm_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsv16x_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_fsm_long_cnt_set(lsm6dsv16x_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv16x_fsm_long_cnt_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
 
 
 typedef struct {
@@ -4388,7 +4388,7 @@ typedef struct {
   uint8_t fsm_outs7;
   uint8_t fsm_outs8;
 } lsm6dsv16x_fsm_out_t;
-int32_t lsm6dsv16x_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val);
+int32_t lsm6dsv16x_fsm_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val);
 
 typedef enum {
   LSM6DSV16X_FSM_15Hz  = 0x0,
@@ -4399,14 +4399,14 @@ typedef enum {
   LSM6DSV16X_FSM_480Hz = 0x5,
   LSM6DSV16X_FSM_960Hz = 0x6,
 } lsm6dsv16x_fsm_data_rate_t;
-int32_t lsm6dsv16x_fsm_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fsm_data_rate_t val);
-int32_t lsm6dsv16x_fsm_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_fsm_data_rate_t *val);
 
-int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx,
                                                 uint16_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
                                                 uint16_t *val);
 
 typedef struct {
@@ -4414,9 +4414,9 @@ typedef struct {
   uint16_t y;
   uint16_t x;
 } lsm6dsv16x_xl_fsm_ext_sens_offset_t;
-int32_t lsm6dsv16x_fsm_ext_sens_offset_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_offset_set(lsm6dsv16x_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_offset_get(lsm6dsv16x_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t *val);
 
 typedef struct {
@@ -4427,9 +4427,9 @@ typedef struct {
   uint16_t yz;
   uint16_t zz;
 } lsm6dsv16x_xl_fsm_ext_sens_matrix_t;
-int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(lsm6dsv16x_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(lsm6dsv16x_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t *val);
 
 typedef enum {
@@ -4440,9 +4440,9 @@ typedef enum {
   LSM6DSV16X_Z_EQ_MIN_Z = 0x4,
   LSM6DSV16X_Z_EQ_Z     = 0x5,
 } lsm6dsv16x_fsm_ext_sens_z_orient_t;
-int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t *val);
 
 typedef enum {
@@ -4453,9 +4453,9 @@ typedef enum {
   LSM6DSV16X_Y_EQ_MIN_Z = 0x4,
   LSM6DSV16X_Y_EQ_Z     = 0x5,
 } lsm6dsv16x_fsm_ext_sens_y_orient_t;
-int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t *val);
 
 typedef enum {
@@ -4466,22 +4466,22 @@ typedef enum {
   LSM6DSV16X_X_EQ_MIN_Z = 0x4,
   LSM6DSV16X_X_EQ_Z     = 0x5,
 } lsm6dsv16x_fsm_ext_sens_x_orient_t;
-int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_x_orient_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_x_orient_t *val);
 
-int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(stmdev_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(lsm6dsv16x_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsv16x_fsm_number_of_programs_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fsm_number_of_programs_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fsm_number_of_programs_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fsm_number_of_programs_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fsm_start_address_set(stmdev_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsv16x_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_fsm_start_address_set(lsm6dsv16x_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv16x_fsm_start_address_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsv16x_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ff_time_windows_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ff_time_windows_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ff_time_windows_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_156_mg = 0x0,
@@ -4493,9 +4493,9 @@ typedef enum {
   LSM6DSV16X_469_mg = 0x6,
   LSM6DSV16X_500_mg = 0x7,
 } lsm6dsv16x_ff_thresholds_t;
-int32_t lsm6dsv16x_ff_thresholds_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ff_thresholds_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t val);
-int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ff_thresholds_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t *val);
 
 typedef enum {
@@ -4503,8 +4503,8 @@ typedef enum {
   LSM6DSV16X_MLC_ON                              = 0x1,
   LSM6DSV16X_MLC_ON_BEFORE_FSM                   = 0x2,
 } lsm6dsv16x_mlc_mode_t;
-int32_t lsm6dsv16x_mlc_set(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val);
-int32_t lsm6dsv16x_mlc_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val);
+int32_t lsm6dsv16x_mlc_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val);
+int32_t lsm6dsv16x_mlc_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val);
 
 typedef enum {
   LSM6DSV16X_MLC_15Hz  = 0x0,
@@ -4515,9 +4515,9 @@ typedef enum {
   LSM6DSV16X_MLC_480Hz = 0x5,
   LSM6DSV16X_MLC_960Hz = 0x6,
 } lsm6dsv16x_mlc_data_rate_t;
-int32_t lsm6dsv16x_mlc_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t val);
-int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t *val);
 
 typedef struct {
@@ -4526,53 +4526,53 @@ typedef struct {
   uint8_t mlc3_src;
   uint8_t mlc4_src;
 } lsm6dsv16x_mlc_out_t;
-int32_t lsm6dsv16x_mlc_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val);
+int32_t lsm6dsv16x_mlc_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val);
 
-int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx,
                                                 uint16_t val);
-int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
                                                 uint16_t *val);
 
 typedef enum {
   LSM6DSV16X_OIS_CTRL_FROM_OIS = 0x0,
   LSM6DSV16X_OIS_CTRL_FROM_UI  = 0x1,
 } lsm6dsv16x_ois_ctrl_mode_t;
-int32_t lsm6dsv16x_ois_ctrl_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_ctrl_mode_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_ois_ctrl_mode_t val);
-int32_t lsm6dsv16x_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_ctrl_mode_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_ois_ctrl_mode_t *val);
 
-int32_t lsm6dsv16x_ois_reset_set(stmdev_ctx_t *ctx, int8_t val);
-int32_t lsm6dsv16x_ois_reset_get(stmdev_ctx_t *ctx, int8_t *val);
+int32_t lsm6dsv16x_ois_reset_set(lsm6dsv16x_ctx_t *ctx, int8_t val);
+int32_t lsm6dsv16x_ois_reset_get(lsm6dsv16x_ctx_t *ctx, int8_t *val);
 
-int32_t lsm6dsv16x_ois_interface_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ois_interface_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ois_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ois_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t ack                  : 1;
   uint8_t req                  : 1;
 } lsm6dsv16x_ois_handshake_t;
-int32_t lsm6dsv16x_ois_handshake_from_ui_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ui_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_ois_handshake_t val);
-int32_t lsm6dsv16x_ois_handshake_from_ui_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ui_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_ois_handshake_t *val);
-int32_t lsm6dsv16x_ois_handshake_from_ois_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ois_set(lsm6dsv16x_ctx_t *ctx,
                                               lsm6dsv16x_ois_handshake_t val);
-int32_t lsm6dsv16x_ois_handshake_from_ois_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ois_get(lsm6dsv16x_ctx_t *ctx,
                                               lsm6dsv16x_ois_handshake_t *val);
 
-int32_t lsm6dsv16x_ois_shared_set(stmdev_ctx_t *ctx, uint8_t val[6]);
-int32_t lsm6dsv16x_ois_shared_get(stmdev_ctx_t *ctx, uint8_t val[6]);
+int32_t lsm6dsv16x_ois_shared_set(lsm6dsv16x_ctx_t *ctx, uint8_t val[6]);
+int32_t lsm6dsv16x_ois_shared_get(lsm6dsv16x_ctx_t *ctx, uint8_t val[6]);
 
-int32_t lsm6dsv16x_ois_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ois_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ois_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ois_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t gy                   : 1;
   uint8_t xl                   : 1;
 } lsm6dsv16x_ois_chain_t;
-int32_t lsm6dsv16x_ois_chain_set(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t val);
-int32_t lsm6dsv16x_ois_chain_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_chain_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_ois_chain_t val);
+int32_t lsm6dsv16x_ois_chain_get(lsm6dsv16x_ctx_t *ctx,
                                  lsm6dsv16x_ois_chain_t *val);
 
 typedef enum {
@@ -4582,9 +4582,9 @@ typedef enum {
   LSM6DSV16X_OIS_1000dps = 0x3,
   LSM6DSV16X_OIS_2000dps = 0x4,
 } lsm6dsv16x_ois_gy_full_scale_t;
-int32_t lsm6dsv16x_ois_gy_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t val);
-int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t *val);
 
 typedef enum {
@@ -4593,9 +4593,9 @@ typedef enum {
   LSM6DSV16X_OIS_8g  = 0x2,
   LSM6DSV16X_OIS_16g = 0x3,
 } lsm6dsv16x_ois_xl_full_scale_t;
-int32_t lsm6dsv16x_ois_xl_full_scale_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t val);
-int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t *val);
 
 typedef enum {
@@ -4604,13 +4604,13 @@ typedef enum {
   LSM6DSV16X_DEG_60 = 0x2,
   LSM6DSV16X_DEG_50 = 0x3,
 } lsm6dsv16x_6d_threshold_t;
-int32_t lsm6dsv16x_6d_threshold_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_6d_threshold_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_6d_threshold_t val);
-int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_6d_threshold_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_6d_threshold_t *val);
 
-int32_t lsm6dsv16x_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_4d_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_4d_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_2400MOhm = 0x0,
@@ -4618,26 +4618,26 @@ typedef enum {
   LSM6DSV16X_300MOhm = 0x2,
   LSM6DSV16X_255MOhm = 0x3,
 } lsm6dsv16x_ah_qvar_zin_t;
-int32_t lsm6dsv16x_ah_qvar_zin_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_zin_set(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t val);
-int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_zin_get(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t *val);
 
 typedef struct {
   uint8_t ah_qvar_en           : 1;
 } lsm6dsv16x_ah_qvar_mode_t;
-int32_t lsm6dsv16x_ah_qvar_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_mode_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t val);
-int32_t lsm6dsv16x_ah_qvar_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_mode_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t *val);
 
 typedef enum {
   LSM6DSV16X_SW_RST_DYN_ADDRESS_RST = 0x0,
   LSM6DSV16X_I3C_GLOBAL_RST         = 0x1,
 } lsm6dsv16x_i3c_reset_mode_t;
-int32_t lsm6dsv16x_i3c_reset_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_reset_mode_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t val);
-int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_reset_mode_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t *val);
 
 typedef enum {
@@ -4646,17 +4646,17 @@ typedef enum {
   LSM6DSV16X_IBI_1ms  = 0x2,
   LSM6DSV16X_IBI_25ms = 0x3,
 } lsm6dsv16x_i3c_ibi_time_t;
-int32_t lsm6dsv16x_i3c_ibi_time_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_ibi_time_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_i3c_ibi_time_t val);
-int32_t lsm6dsv16x_i3c_ibi_time_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_ibi_time_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_i3c_ibi_time_t *val);
 
-int32_t lsm6dsv16x_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_master_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx,
                                                    uint8_t val);
-int32_t lsm6dsv16x_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_master_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx,
                                                    uint8_t *val);
 
-int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
+int32_t lsm6dsv16x_sh_read_data_raw_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val,
                                         uint8_t len);
 
 typedef enum {
@@ -4665,44 +4665,44 @@ typedef enum {
   LSM6DSV16X_SLV_0_1_2   = 0x2,
   LSM6DSV16X_SLV_0_1_2_3 = 0x3,
 } lsm6dsv16x_sh_slave_connected_t;
-int32_t lsm6dsv16x_sh_slave_connected_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_slave_connected_set(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_sh_slave_connected_t val);
-int32_t lsm6dsv16x_sh_slave_connected_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_slave_connected_get(lsm6dsv16x_ctx_t *ctx,
                                           lsm6dsv16x_sh_slave_connected_t *val);
 
-int32_t lsm6dsv16x_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sh_master_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sh_master_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sh_pass_through_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sh_pass_through_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_SH_TRG_XL_GY_DRDY = 0x0,
   LSM6DSV16X_SH_TRIG_INT2      = 0x1,
 } lsm6dsv16x_sh_syncro_mode_t;
-int32_t lsm6dsv16x_sh_syncro_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_syncro_mode_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t val);
-int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_syncro_mode_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t *val);
 
 typedef enum {
   LSM6DSV16X_EACH_SH_CYCLE    = 0x0,
   LSM6DSV16X_ONLY_FIRST_CYCLE = 0x1,
 } lsm6dsv16x_sh_write_mode_t;
-int32_t lsm6dsv16x_sh_write_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_write_mode_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_sh_write_mode_t val);
-int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_write_mode_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_sh_write_mode_t *val);
 
-int32_t lsm6dsv16x_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sh_reset_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sh_reset_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t   slv0_add;
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } lsm6dsv16x_sh_cfg_write_t;
-int32_t lsm6dsv16x_sh_cfg_write(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_cfg_write(lsm6dsv16x_ctx_t *ctx,
                                 lsm6dsv16x_sh_cfg_write_t *val);
 typedef enum {
   LSM6DSV16X_SH_15Hz  = 0x1,
@@ -4712,9 +4712,9 @@ typedef enum {
   LSM6DSV16X_SH_240Hz = 0x5,
   LSM6DSV16X_SH_480Hz = 0x6,
 } lsm6dsv16x_sh_data_rate_t;
-int32_t lsm6dsv16x_sh_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t val);
-int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t *val);
 
 typedef struct {
@@ -4722,74 +4722,74 @@ typedef struct {
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dsv16x_sh_cfg_read_t;
-int32_t lsm6dsv16x_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
+int32_t lsm6dsv16x_sh_slv_cfg_read(lsm6dsv16x_ctx_t *ctx, uint8_t idx,
                                    lsm6dsv16x_sh_cfg_read_t *val);
 
-int32_t lsm6dsv16x_sh_status_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_status_get(lsm6dsv16x_ctx_t *ctx,
                                  lsm6dsv16x_status_master_t *val);
 
-int32_t lsm6dsv16x_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ui_sdo_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ui_sdo_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ui_sdo_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_I2C_I3C_ENABLE  = 0x0,
   LSM6DSV16X_I2C_I3C_DISABLE = 0x1,
 } lsm6dsv16x_ui_i2c_i3c_mode_t;
-int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t val);
-int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t *val);
 
 typedef enum {
   LSM6DSV16X_SPI_4_WIRE = 0x0,
   LSM6DSV16X_SPI_3_WIRE = 0x1,
 } lsm6dsv16x_spi_mode_t;
-int32_t lsm6dsv16x_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t val);
-int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val);
+int32_t lsm6dsv16x_spi_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t val);
+int32_t lsm6dsv16x_spi_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val);
 
-int32_t lsm6dsv16x_ui_sda_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ui_sda_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ui_sda_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ui_sda_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_SPI2_4_WIRE = 0x0,
   LSM6DSV16X_SPI2_3_WIRE = 0x1,
 } lsm6dsv16x_spi2_mode_t;
-int32_t lsm6dsv16x_spi2_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val);
-int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_spi2_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val);
+int32_t lsm6dsv16x_spi2_mode_get(lsm6dsv16x_ctx_t *ctx,
                                  lsm6dsv16x_spi2_mode_t *val);
 
-int32_t lsm6dsv16x_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sigmot_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sigmot_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   uint8_t step_counter_enable  : 1;
   uint8_t false_step_rej       : 1;
 } lsm6dsv16x_stpcnt_mode_t;
-int32_t lsm6dsv16x_stpcnt_mode_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_stpcnt_mode_set(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_stpcnt_mode_t val);
-int32_t lsm6dsv16x_stpcnt_mode_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_stpcnt_mode_get(lsm6dsv16x_ctx_t *ctx,
                                    lsm6dsv16x_stpcnt_mode_t *val);
 
-int32_t lsm6dsv16x_stpcnt_steps_get(stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_stpcnt_steps_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsv16x_stpcnt_rst_step_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_stpcnt_rst_step_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_stpcnt_rst_step_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_stpcnt_rst_step_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_stpcnt_debounce_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_stpcnt_debounce_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_stpcnt_debounce_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_stpcnt_debounce_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_stpcnt_period_set(stmdev_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsv16x_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_stpcnt_period_set(lsm6dsv16x_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv16x_stpcnt_period_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsv16x_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sflp_game_rotation_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sflp_game_rotation_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef struct {
   float_t gbias_x; /* dps */
   float_t gbias_y; /* dps */
   float_t gbias_z; /* dps */
 } lsm6dsv16x_sflp_gbias_t;
-int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
                                        lsm6dsv16x_sflp_gbias_t *val);
 
 typedef enum {
@@ -4800,9 +4800,9 @@ typedef enum {
   LSM6DSV16X_SFLP_240Hz = 0x4,
   LSM6DSV16X_SFLP_480Hz = 0x5,
 } lsm6dsv16x_sflp_data_rate_t;
-int32_t lsm6dsv16x_sflp_data_rate_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_data_rate_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t val);
-int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_data_rate_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t *val);
 
 typedef struct {
@@ -4810,9 +4810,9 @@ typedef struct {
   uint8_t tap_y_en             : 1;
   uint8_t tap_z_en             : 1;
 } lsm6dsv16x_tap_detection_t;
-int32_t lsm6dsv16x_tap_detection_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_detection_set(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t val);
-int32_t lsm6dsv16x_tap_detection_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_detection_get(lsm6dsv16x_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t *val);
 
 typedef struct {
@@ -4820,9 +4820,9 @@ typedef struct {
   uint8_t y                    : 5;
   uint8_t z                    : 5;
 } lsm6dsv16x_tap_thresholds_t;
-int32_t lsm6dsv16x_tap_thresholds_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_thresholds_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t val);
-int32_t lsm6dsv16x_tap_thresholds_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_thresholds_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t *val);
 
 typedef enum {
@@ -4833,9 +4833,9 @@ typedef enum {
   LSM6DSV16X_YZX  = 0x5,
   LSM6DSV16X_ZXY  = 0x6,
 } lsm6dsv16x_tap_axis_priority_t;
-int32_t lsm6dsv16x_tap_axis_priority_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_axis_priority_set(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t val);
-int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_axis_priority_get(lsm6dsv16x_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t *val);
 
 typedef struct {
@@ -4843,25 +4843,25 @@ typedef struct {
   uint8_t quiet                : 2;
   uint8_t tap_gap              : 4;
 } lsm6dsv16x_tap_time_windows_t;
-int32_t lsm6dsv16x_tap_time_windows_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_time_windows_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t val);
-int32_t lsm6dsv16x_tap_time_windows_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_time_windows_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t *val);
 
 typedef enum {
   LSM6DSV16X_ONLY_SINGLE        = 0x0,
   LSM6DSV16X_BOTH_SINGLE_DOUBLE = 0x1,
 } lsm6dsv16x_tap_mode_t;
-int32_t lsm6dsv16x_tap_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t val);
-int32_t lsm6dsv16x_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val);
+int32_t lsm6dsv16x_tap_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t val);
+int32_t lsm6dsv16x_tap_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val);
 
-int32_t lsm6dsv16x_tilt_mode_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_tilt_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_tilt_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_tilt_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val);
+int32_t lsm6dsv16x_timestamp_raw_get(lsm6dsv16x_ctx_t *ctx, uint32_t *val);
 
-int32_t lsm6dsv16x_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_timestamp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_timestamp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
 
 typedef enum {
   LSM6DSV16X_XL_AND_GY_NOT_AFFECTED       = 0x0,
@@ -4869,8 +4869,8 @@ typedef enum {
   LSM6DSV16X_XL_LOW_POWER_GY_SLEEP        = 0x2,
   LSM6DSV16X_XL_LOW_POWER_GY_POWER_DOWN   = 0x3,
 } lsm6dsv16x_act_mode_t;
-int32_t lsm6dsv16x_act_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t val);
-int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val);
+int32_t lsm6dsv16x_act_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t val);
+int32_t lsm6dsv16x_act_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t *val);
 
 typedef enum {
   LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE = 0x0,
@@ -4878,9 +4878,9 @@ typedef enum {
   LSM6DSV16X_SLEEP_TO_ACT_AT_3RD_SAMPLE = 0x2,
   LSM6DSV16X_SLEEP_TO_ACT_AT_4th_SAMPLE = 0x3,
 } lsm6dsv16x_act_from_sleep_to_act_dur_t;
-int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(lsm6dsv16x_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t val);
-int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(lsm6dsv16x_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t *val);
 
 typedef enum {
@@ -4889,9 +4889,9 @@ typedef enum {
   LSM6DSV16X_30Hz   = 0x2,
   LSM6DSV16X_60Hz   = 0x3,
 } lsm6dsv16x_act_sleep_xl_odr_t;
-int32_t lsm6dsv16x_act_sleep_xl_odr_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_sleep_xl_odr_set(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t val);
-int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_sleep_xl_odr_get(lsm6dsv16x_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t *val);
 
 typedef struct {
@@ -4900,18 +4900,18 @@ typedef struct {
   uint8_t threshold;
   uint8_t duration;
 } lsm6dsv16x_act_thresholds_t;
-int32_t lsm6dsv16x_act_thresholds_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_thresholds_set(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val);
-int32_t lsm6dsv16x_act_thresholds_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_thresholds_get(lsm6dsv16x_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val);
 
 typedef struct {
   uint8_t shock                : 2;
   uint8_t quiet                : 4;
 } lsm6dsv16x_act_wkup_time_windows_t;
-int32_t lsm6dsv16x_act_wkup_time_windows_set(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_wkup_time_windows_set(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_act_wkup_time_windows_t val);
-int32_t lsm6dsv16x_act_wkup_time_windows_get(stmdev_ctx_t *ctx,
+int32_t lsm6dsv16x_act_wkup_time_windows_get(lsm6dsv16x_ctx_t *ctx,
                                              lsm6dsv16x_act_wkup_time_windows_t *val);
 
 /**

--- a/src/lsm6dsv16x_reg.h
+++ b/src/lsm6dsv16x_reg.h
@@ -75,8 +75,7 @@ extern "C" {
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
 
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t bit0       : 1;
   uint8_t bit1       : 1;
@@ -113,8 +112,7 @@ typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, const uint8_t *, uint16_t);
 typedef int32_t (*stmdev_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
 typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
 
-typedef struct
-{
+typedef struct {
   /** Component mandatory fields **/
   stmdev_write_ptr  write_reg;
   stmdev_read_ptr   read_reg;
@@ -145,8 +143,7 @@ typedef struct
   *
   */
 
-typedef struct
-{
+typedef struct {
   uint8_t address;
   uint8_t data;
 } ucf_line_t;
@@ -186,8 +183,7 @@ typedef struct
   */
 
 #define LSM6DSV16X_FUNC_CFG_ACCESS              0x1U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ois_ctrl_from_ui     : 1;
   uint8_t spi2_reset           : 1;
@@ -208,8 +204,7 @@ typedef struct
 } lsm6dsv16x_func_cfg_access_t;
 
 #define LSM6DSV16X_PIN_CTRL                     0x2U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 5;
   uint8_t ibhr_por_en          : 1;
@@ -224,8 +219,7 @@ typedef struct
 } lsm6dsv16x_pin_ctrl_t;
 
 #define LSM6DSV16X_IF_CFG                       0x3U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t i2c_i3c_disable      : 1;
   uint8_t not_used0            : 1;
@@ -248,8 +242,7 @@ typedef struct
 } lsm6dsv16x_if_cfg_t;
 
 #define LSM6DSV16X_ODR_TRIG_CFG                 0x6U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t odr_trig_nodr        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -258,8 +251,7 @@ typedef struct
 } lsm6dsv16x_odr_trig_cfg_t;
 
 #define LSM6DSV16X_FIFO_CTRL1                   0x7U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t wtm                  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -268,8 +260,7 @@ typedef struct
 } lsm6dsv16x_fifo_ctrl1_t;
 
 #define LSM6DSV16X_FIFO_CTRL2                   0x8U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xl_dualc_batch_from_fsm       : 1;
   uint8_t uncompr_rate                  : 2;
@@ -290,8 +281,7 @@ typedef struct
 } lsm6dsv16x_fifo_ctrl2_t;
 
 #define LSM6DSV16X_FIFO_CTRL3                  0x9U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t bdr_xl               : 4;
   uint8_t bdr_gy               : 4;
@@ -302,8 +292,7 @@ typedef struct
 } lsm6dsv16x_fifo_ctrl3_t;
 
 #define LSM6DSV16X_FIFO_CTRL4                  0x0AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_mode            : 3;
   uint8_t g_eis_fifo_en        : 1;
@@ -318,8 +307,7 @@ typedef struct
 } lsm6dsv16x_fifo_ctrl4_t;
 
 #define LSM6DSV16X_COUNTER_BDR_REG1            0x0BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t cnt_bdr_th           : 2;
   uint8_t not_used0            : 3;
@@ -334,8 +322,7 @@ typedef struct
 } lsm6dsv16x_counter_bdr_reg1_t;
 
 #define LSM6DSV16X_COUNTER_BDR_REG2            0x0CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t cnt_bdr_th           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -344,8 +331,7 @@ typedef struct
 } lsm6dsv16x_counter_bdr_reg2_t;
 
 #define LSM6DSV16X_INT1_CTRL                   0x0DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int1_drdy_xl         : 1;
   uint8_t int1_drdy_g          : 1;
@@ -368,8 +354,7 @@ typedef struct
 } lsm6dsv16x_int1_ctrl_t;
 
 #define LSM6DSV16X_INT2_CTRL                   0x0EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_drdy_xl         : 1;
   uint8_t int2_drdy_g          : 1;
@@ -392,8 +377,7 @@ typedef struct
 } lsm6dsv16x_int2_ctrl_t;
 
 #define LSM6DSV16X_WHO_AM_I                    0x0FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t id                   : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -402,8 +386,7 @@ typedef struct
 } lsm6dsv16x_who_am_i_t;
 
 #define LSM6DSV16X_CTRL1                       0x10U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t odr_xl               : 4;
   uint8_t op_mode_xl           : 3;
@@ -416,8 +399,7 @@ typedef struct
 } lsm6dsv16x_ctrl1_t;
 
 #define LSM6DSV16X_CTRL2                       0x11U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t odr_g                : 4;
   uint8_t op_mode_g            : 3;
@@ -430,8 +412,7 @@ typedef struct
 } lsm6dsv16x_ctrl2_t;
 
 #define LSM6DSV16X_CTRL3                       0x12U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sw_reset             : 1;
   uint8_t not_used0            : 1;
@@ -450,8 +431,7 @@ typedef struct
 } lsm6dsv16x_ctrl3_t;
 
 #define LSM6DSV16X_CTRL4                       0x13U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_in_lh           : 1;
   uint8_t drdy_pulsed          : 1;
@@ -470,8 +450,7 @@ typedef struct
 } lsm6dsv16x_ctrl4_t;
 
 #define LSM6DSV16X_CTRL5                       0x14U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int_en_i3c           : 1;
   uint8_t bus_act_sel          : 2;
@@ -484,8 +463,7 @@ typedef struct
 } lsm6dsv16x_ctrl5_t;
 
 #define LSM6DSV16X_CTRL6                       0x15U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_g                 : 4;
   uint8_t lpf1_g_bw            : 3;
@@ -498,8 +476,7 @@ typedef struct
 } lsm6dsv16x_ctrl6_t;
 
 #define LSM6DSV16X_CTRL7                       0x16U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t lpf1_g_en            : 1;
   uint8_t not_used0            : 3;
@@ -516,8 +493,7 @@ typedef struct
 } lsm6dsv16x_ctrl7_t;
 
 #define LSM6DSV16X_CTRL8                       0x17U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_xl                : 2;
   uint8_t not_used0            : 1;
@@ -534,8 +510,7 @@ typedef struct
 } lsm6dsv16x_ctrl8_t;
 
 #define LSM6DSV16X_CTRL9                       0x18U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t usr_off_on_out       : 1;
   uint8_t usr_off_w            : 1;
@@ -558,8 +533,7 @@ typedef struct
 } lsm6dsv16x_ctrl9_t;
 
 #define LSM6DSV16X_CTRL10                      0x19U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t st_xl                : 2;
   uint8_t st_g                 : 2;
@@ -576,8 +550,7 @@ typedef struct
 } lsm6dsv16x_ctrl10_t;
 
 #define LSM6DSV16X_CTRL_STATUS                 0x1AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 2;
   uint8_t fsm_wr_ctrl_status   : 1;
@@ -590,8 +563,7 @@ typedef struct
 } lsm6dsv16x_ctrl_status_t;
 
 #define LSM6DSV16X_FIFO_STATUS1                0x1BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t diff_fifo            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -600,8 +572,7 @@ typedef struct
 } lsm6dsv16x_fifo_status1_t;
 
 #define LSM6DSV16X_FIFO_STATUS2                0x1CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t diff_fifo            : 1;
   uint8_t not_used0            : 2;
@@ -622,8 +593,7 @@ typedef struct
 } lsm6dsv16x_fifo_status2_t;
 
 #define LSM6DSV16X_ALL_INT_SRC                 0x1DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ff_ia                : 1;
   uint8_t wu_ia                : 1;
@@ -646,8 +616,7 @@ typedef struct
 } lsm6dsv16x_all_int_src_t;
 
 #define LSM6DSV16X_STATUS_REG                  0x1EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xlda                 : 1;
   uint8_t gda                  : 1;
@@ -670,8 +639,7 @@ typedef struct
 } lsm6dsv16x_status_reg_t;
 
 #define LSM6DSV16X_OUT_TEMP_L                  0x20U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t temp                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -680,8 +648,7 @@ typedef struct
 } lsm6dsv16x_out_temp_l_t;
 
 #define LSM6DSV16X_OUT_TEMP_H                  0x21U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t temp                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -690,8 +657,7 @@ typedef struct
 } lsm6dsv16x_out_temp_h_t;
 
 #define LSM6DSV16X_OUTX_L_G                    0x22U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outx_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -700,8 +666,7 @@ typedef struct
 } lsm6dsv16x_outx_l_g_t;
 
 #define LSM6DSV16X_OUTX_H_G                    0x23U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outx_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -710,8 +675,7 @@ typedef struct
 } lsm6dsv16x_outx_h_g_t;
 
 #define LSM6DSV16X_OUTY_L_G                    0x24U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outy_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -720,8 +684,7 @@ typedef struct
 } lsm6dsv16x_outy_l_g_t;
 
 #define LSM6DSV16X_OUTY_H_G                    0x25U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outy_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -730,8 +693,7 @@ typedef struct
 } lsm6dsv16x_outy_h_g_t;
 
 #define LSM6DSV16X_OUTZ_L_G                    0x26U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outz_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -740,8 +702,7 @@ typedef struct
 } lsm6dsv16x_outz_l_g_t;
 
 #define LSM6DSV16X_OUTZ_H_G                    0x27U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outz_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -750,8 +711,7 @@ typedef struct
 } lsm6dsv16x_outz_h_g_t;
 
 #define LSM6DSV16X_OUTX_L_A                    0x28U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outx_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -760,8 +720,7 @@ typedef struct
 } lsm6dsv16x_outx_l_a_t;
 
 #define LSM6DSV16X_OUTX_H_A                    0x29U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outx_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -770,8 +729,7 @@ typedef struct
 } lsm6dsv16x_outx_h_a_t;
 
 #define LSM6DSV16X_OUTY_L_A                    0x2AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outy_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -780,8 +738,7 @@ typedef struct
 } lsm6dsv16x_outy_l_a_t;
 
 #define LSM6DSV16X_OUTY_H_A                    0x2BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outy_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -790,8 +747,7 @@ typedef struct
 } lsm6dsv16x_outy_h_a_t;
 
 #define LSM6DSV16X_OUTZ_L_A                    0x2CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outz_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -800,8 +756,7 @@ typedef struct
 } lsm6dsv16x_outz_l_a_t;
 
 #define LSM6DSV16X_OUTZ_H_A                    0x2DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outz_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -810,8 +765,7 @@ typedef struct
 } lsm6dsv16x_outz_h_a_t;
 
 #define LSM6DSV16X_UI_OUTX_L_G_OIS_EIS         0x2EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outx_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -820,8 +774,7 @@ typedef struct
 } lsm6dsv16x_ui_outx_l_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTX_H_G_OIS_EIS         0x2FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outx_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -830,8 +783,7 @@ typedef struct
 } lsm6dsv16x_ui_outx_h_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTY_L_G_OIS_EIS         0x30U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outy_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -840,8 +792,7 @@ typedef struct
 } lsm6dsv16x_ui_outy_l_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTY_H_G_OIS_EIS         0x31U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outy_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -850,8 +801,7 @@ typedef struct
 } lsm6dsv16x_ui_outy_h_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTZ_L_G_OIS_EIS         0x32U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outz_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -860,8 +810,7 @@ typedef struct
 } lsm6dsv16x_ui_outz_l_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTZ_H_G_OIS_EIS         0x33U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outz_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -870,8 +819,7 @@ typedef struct
 } lsm6dsv16x_ui_outz_h_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTX_L_A_OIS_DUALC       0x34U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outx_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -880,8 +828,7 @@ typedef struct
 } lsm6dsv16x_ui_outx_l_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTX_H_A_OIS_DUALC       0x35U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outx_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -890,8 +837,7 @@ typedef struct
 } lsm6dsv16x_ui_outx_h_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTY_L_A_OIS_DUALC       0x36U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outy_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -900,8 +846,7 @@ typedef struct
 } lsm6dsv16x_ui_outy_l_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTY_H_A_OIS_DUALC       0x37U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outy_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -910,8 +855,7 @@ typedef struct
 } lsm6dsv16x_ui_outy_h_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTZ_L_A_OIS_DUALC       0x38U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outz_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -920,8 +864,7 @@ typedef struct
 } lsm6dsv16x_ui_outz_l_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTZ_H_A_OIS_DUALC       0x39U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outz_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -930,8 +873,7 @@ typedef struct
 } lsm6dsv16x_ui_outz_h_a_ois_dualc_t;
 
 #define LSM6DSV16X_AH_QVAR_OUT_L               0x3AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ah_qvar              : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -940,8 +882,7 @@ typedef struct
 } lsm6dsv16x_ah_qvar_out_l_t;
 
 #define LSM6DSV16X_AH_QVAR_OUT_H               0x3BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ah_qvar              : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -950,8 +891,7 @@ typedef struct
 } lsm6dsv16x_ah_qvar_out_h_t;
 
 #define LSM6DSV16X_TIMESTAMP0                  0x40U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t timestamp            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -960,8 +900,7 @@ typedef struct
 } lsm6dsv16x_timestamp0_t;
 
 #define LSM6DSV16X_TIMESTAMP1                  0x41U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t timestamp            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -970,8 +909,7 @@ typedef struct
 } lsm6dsv16x_timestamp1_t;
 
 #define LSM6DSV16X_TIMESTAMP2                  0x42U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t timestamp            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -980,8 +918,7 @@ typedef struct
 } lsm6dsv16x_timestamp2_t;
 
 #define LSM6DSV16X_TIMESTAMP3                  0x43U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t timestamp            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -990,8 +927,7 @@ typedef struct
 } lsm6dsv16x_timestamp3_t;
 
 #define LSM6DSV16X_UI_STATUS_REG_OIS           0x44U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xlda_ois             : 1;
   uint8_t gda_ois              : 1;
@@ -1006,8 +942,7 @@ typedef struct
 } lsm6dsv16x_ui_status_reg_ois_t;
 
 #define LSM6DSV16X_WAKE_UP_SRC                 0x45U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t z_wu                 : 1;
   uint8_t y_wu                 : 1;
@@ -1030,8 +965,7 @@ typedef struct
 } lsm6dsv16x_wake_up_src_t;
 
 #define LSM6DSV16X_TAP_SRC                     0x46U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t z_tap                : 1;
   uint8_t y_tap                : 1;
@@ -1054,8 +988,7 @@ typedef struct
 } lsm6dsv16x_tap_src_t;
 
 #define LSM6DSV16X_D6D_SRC                     0x47U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xl                   : 1;
   uint8_t xh                   : 1;
@@ -1078,8 +1011,7 @@ typedef struct
 } lsm6dsv16x_d6d_src_t;
 
 #define LSM6DSV16X_STATUS_MASTER_MAINPAGE      0x48U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sens_hub_endop       : 1;
   uint8_t not_used0            : 2;
@@ -1100,8 +1032,7 @@ typedef struct
 } lsm6dsv16x_status_master_mainpage_t;
 
 #define LSM6DSV16X_EMB_FUNC_STATUS_MAINPAGE    0x49U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t is_step_det          : 1;
@@ -1120,8 +1051,7 @@ typedef struct
 } lsm6dsv16x_emb_func_status_mainpage_t;
 
 #define LSM6DSV16X_FSM_STATUS_MAINPAGE         0x4AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t is_fsm1              : 1;
   uint8_t is_fsm2              : 1;
@@ -1144,8 +1074,7 @@ typedef struct
 } lsm6dsv16x_fsm_status_mainpage_t;
 
 #define LSM6DSV16X_MLC_STATUS_MAINPAGE         0x4BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t is_mlc1              : 1;
   uint8_t is_mlc2              : 1;
@@ -1162,8 +1091,7 @@ typedef struct
 } lsm6dsv16x_mlc_status_mainpage_t;
 
 #define LSM6DSV16X_INTERNAL_FREQ               0x4FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t freq_fine            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1172,8 +1100,7 @@ typedef struct
 } lsm6dsv16x_internal_freq_t;
 
 #define LSM6DSV16X_FUNCTIONS_ENABLE            0x50U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t inact_en             : 2;
   uint8_t not_used0            : 1;
@@ -1192,8 +1119,7 @@ typedef struct
 } lsm6dsv16x_functions_enable_t;
 
 #define LSM6DSV16X_DEN                         0x51U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t den_xl_g             : 1;
   uint8_t den_z                : 1;
@@ -1216,8 +1142,7 @@ typedef struct
 } lsm6dsv16x_den_t;
 
 #define LSM6DSV16X_INACTIVITY_DUR              0x54U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t inact_dur            : 2;
   uint8_t xl_inact_odr         : 2;
@@ -1232,8 +1157,7 @@ typedef struct
 } lsm6dsv16x_inactivity_dur_t;
 
 #define LSM6DSV16X_INACTIVITY_THS              0x55U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t inact_ths            : 6;
   uint8_t not_used0            : 2;
@@ -1244,8 +1168,7 @@ typedef struct
 } lsm6dsv16x_inactivity_ths_t;
 
 #define LSM6DSV16X_TAP_CFG0                    0x56U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t lir                  : 1;
   uint8_t tap_z_en             : 1;
@@ -1268,8 +1191,7 @@ typedef struct
 } lsm6dsv16x_tap_cfg0_t;
 
 #define LSM6DSV16X_TAP_CFG1                    0x57U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t tap_ths_x            : 5;
   uint8_t tap_priority         : 3;
@@ -1280,8 +1202,7 @@ typedef struct
 } lsm6dsv16x_tap_cfg1_t;
 
 #define LSM6DSV16X_TAP_CFG2                    0x58U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t tap_ths_y            : 5;
   uint8_t not_used0            : 3;
@@ -1292,8 +1213,7 @@ typedef struct
 } lsm6dsv16x_tap_cfg2_t;
 
 #define LSM6DSV16X_TAP_THS_6D                  0x59U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t tap_ths_z            : 5;
   uint8_t sixd_ths             : 2;
@@ -1306,8 +1226,7 @@ typedef struct
 } lsm6dsv16x_tap_ths_6d_t;
 
 #define LSM6DSV16X_TAP_DUR                     0x5AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t shock                : 2;
   uint8_t quiet                : 2;
@@ -1320,8 +1239,7 @@ typedef struct
 } lsm6dsv16x_tap_dur_t;
 
 #define LSM6DSV16X_WAKE_UP_THS                 0x5BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t wk_ths               : 6;
   uint8_t usr_off_on_wu        : 1;
@@ -1334,8 +1252,7 @@ typedef struct
 } lsm6dsv16x_wake_up_ths_t;
 
 #define LSM6DSV16X_WAKE_UP_DUR                 0x5CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sleep_dur            : 4;
   uint8_t not_used0            : 1;
@@ -1350,8 +1267,7 @@ typedef struct
 } lsm6dsv16x_wake_up_dur_t;
 
 #define LSM6DSV16X_FREE_FALL                   0x5DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ff_ths               : 3;
   uint8_t ff_dur               : 5;
@@ -1362,8 +1278,7 @@ typedef struct
 } lsm6dsv16x_free_fall_t;
 
 #define LSM6DSV16X_MD1_CFG                    0x5EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int1_shub            : 1;
   uint8_t int1_emb_func        : 1;
@@ -1386,8 +1301,7 @@ typedef struct
 } lsm6dsv16x_md1_cfg_t;
 
 #define LSM6DSV16X_MD2_CFG                    0x5FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_timestamp       : 1;
   uint8_t int2_emb_func        : 1;
@@ -1410,8 +1324,7 @@ typedef struct
 } lsm6dsv16x_md2_cfg_t;
 
 #define LSM6DSV16X_HAODR_CFG                  0x62U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t haodr_sel            : 2;
   uint8_t not_used0            : 6;
@@ -1422,8 +1335,7 @@ typedef struct
 } lsm6dsv16x_haodr_cfg_t;
 
 #define LSM6DSV16X_EMB_FUNC_CFG               0x63U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t emb_func_disable     : 1;
@@ -1440,8 +1352,7 @@ typedef struct
 } lsm6dsv16x_emb_func_cfg_t;
 
 #define LSM6DSV16X_UI_HANDSHAKE_CTRL          0x64U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_shared_req        : 1;
   uint8_t ui_shared_ack        : 1;
@@ -1454,8 +1365,7 @@ typedef struct
 } lsm6dsv16x_ui_handshake_ctrl_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_0           0x65U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1464,8 +1374,7 @@ typedef struct
 } lsm6dsv16x_ui_spi2_shared_0_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_1           0x66U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1474,8 +1383,7 @@ typedef struct
 } lsm6dsv16x_ui_spi2_shared_1_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_2           0x67U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1484,8 +1392,7 @@ typedef struct
 } lsm6dsv16x_ui_spi2_shared_2_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_3           0x68U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1494,8 +1401,7 @@ typedef struct
 } lsm6dsv16x_ui_spi2_shared_3_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_4           0x69U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1504,8 +1410,7 @@ typedef struct
 } lsm6dsv16x_ui_spi2_shared_4_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_5           0x6AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1514,8 +1419,7 @@ typedef struct
 } lsm6dsv16x_ui_spi2_shared_5_t;
 
 #define LSM6DSV16X_CTRL_EIS                   0x6BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_g_eis             : 3;
   uint8_t g_eis_on_g_ois_out_reg : 1;
@@ -1532,8 +1436,7 @@ typedef struct
 } lsm6dsv16x_ctrl_eis_t;
 
 #define LSM6DSV16X_UI_INT_OIS                 0x6FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 4;
   uint8_t st_ois_clampdis      : 1;
@@ -1550,8 +1453,7 @@ typedef struct
 } lsm6dsv16x_ui_int_ois_t;
 
 #define LSM6DSV16X_UI_CTRL1_OIS               0x70U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_read_en         : 1;
   uint8_t ois_g_en             : 1;
@@ -1570,8 +1472,7 @@ typedef struct
 } lsm6dsv16x_ui_ctrl1_ois_t;
 
 #define LSM6DSV16X_UI_CTRL2_OIS               0x71U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_g_ois             : 3;
   uint8_t lpf1_g_ois_bw        : 2;
@@ -1584,8 +1485,7 @@ typedef struct
 } lsm6dsv16x_ui_ctrl2_ois_t;
 
 #define LSM6DSV16X_UI_CTRL3_OIS               0x72U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_xl_ois            : 2;
   uint8_t not_used0            : 1;
@@ -1600,8 +1500,7 @@ typedef struct
 } lsm6dsv16x_ui_ctrl3_ois_t;
 
 #define LSM6DSV16X_X_OFS_USR                  0x73U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t x_ofs_usr            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1610,8 +1509,7 @@ typedef struct
 } lsm6dsv16x_x_ofs_usr_t;
 
 #define LSM6DSV16X_Y_OFS_USR                  0x74U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t y_ofs_usr            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1620,8 +1518,7 @@ typedef struct
 } lsm6dsv16x_y_ofs_usr_t;
 
 #define LSM6DSV16X_Z_OFS_USR                  0x75U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t z_ofs_usr            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1630,8 +1527,7 @@ typedef struct
 } lsm6dsv16x_z_ofs_usr_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_TAG          0x78U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 1;
   uint8_t tag_cnt              : 2;
@@ -1644,8 +1540,7 @@ typedef struct
 } lsm6dsv16x_fifo_data_out_tag_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_X_L          0x79U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1654,8 +1549,7 @@ typedef struct
 } lsm6dsv16x_fifo_data_out_x_l_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_X_H          0x7AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1664,8 +1558,7 @@ typedef struct
 } lsm6dsv16x_fifo_data_out_x_h_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_Y_L          0x7BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1674,8 +1567,7 @@ typedef struct
 } lsm6dsv16x_fifo_data_out_y_l_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_Y_H          0x7CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1684,8 +1576,7 @@ typedef struct
 } lsm6dsv16x_fifo_data_out_y_h_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_Z_L          0x7DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1694,8 +1585,7 @@ typedef struct
 } lsm6dsv16x_fifo_data_out_z_l_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_Z_H          0x7EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1714,8 +1604,7 @@ typedef struct
   */
 
 #define LSM6DSV16X_SPI2_WHO_AM_I              0x0FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t id                   : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1724,8 +1613,7 @@ typedef struct
 } lsm6dsv16x_spi2_who_am_i_t;
 
 #define LSM6DSV16X_SPI2_STATUS_REG_OIS        0x1EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xlda                 : 1;
   uint8_t gda                  : 1;
@@ -1740,8 +1628,7 @@ typedef struct
 } lsm6dsv16x_spi2_status_reg_ois_t;
 
 #define LSM6DSV16X_SPI2_OUT_TEMP_L            0x20U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t temp                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1750,8 +1637,7 @@ typedef struct
 } lsm6dsv16x_spi2_out_temp_l_t;
 
 #define LSM6DSV16X_SPI2_OUT_TEMP_H            0x21U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t temp                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1760,8 +1646,7 @@ typedef struct
 } lsm6dsv16x_spi2_out_temp_h_t;
 
 #define LSM6DSV16X_SPI2_OUTX_L_G_OIS          0x22U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outx_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1770,8 +1655,7 @@ typedef struct
 } lsm6dsv16x_spi2_outx_l_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTX_H_G_OIS          0x23U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outx_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1780,8 +1664,7 @@ typedef struct
 } lsm6dsv16x_spi2_outx_h_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTY_L_G_OIS          0x24U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outy_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1790,8 +1673,7 @@ typedef struct
 } lsm6dsv16x_spi2_outy_l_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTY_H_G_OIS          0x25U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outy_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1800,8 +1682,7 @@ typedef struct
 } lsm6dsv16x_spi2_outy_h_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTZ_L_G_OIS          0x26U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outz_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1810,8 +1691,7 @@ typedef struct
 } lsm6dsv16x_spi2_outz_l_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTZ_H_G_OIS          0x27U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outz_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1820,8 +1700,7 @@ typedef struct
 } lsm6dsv16x_spi2_outz_h_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTX_L_A_OIS          0x28U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outx_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1830,8 +1709,7 @@ typedef struct
 } lsm6dsv16x_spi2_outx_l_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTX_H_A_OIS          0x29U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outx_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1840,8 +1718,7 @@ typedef struct
 } lsm6dsv16x_spi2_outx_h_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTY_L_A_OIS          0x2AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outy_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1850,8 +1727,7 @@ typedef struct
 } lsm6dsv16x_spi2_outy_l_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTY_H_A_OIS          0x2BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outy_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1860,8 +1736,7 @@ typedef struct
 } lsm6dsv16x_spi2_outy_h_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTZ_L_A_OIS          0x2CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outz_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1870,8 +1745,7 @@ typedef struct
 } lsm6dsv16x_spi2_outz_l_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTZ_H_A_OIS          0x2DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outz_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1880,8 +1754,7 @@ typedef struct
 } lsm6dsv16x_spi2_outz_h_a_ois_t;
 
 #define LSM6DSV16X_SPI2_HANDSHAKE_CTRL        0x6EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_shared_ack      : 1;
   uint8_t spi2_shared_req      : 1;
@@ -1894,8 +1767,7 @@ typedef struct
 } lsm6dsv16x_spi2_handshake_ctrl_t;
 
 #define LSM6DSV16X_SPI2_INT_OIS               0x6FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t st_xl_ois            : 2;
   uint8_t st_g_ois             : 2;
@@ -1914,8 +1786,7 @@ typedef struct
 } lsm6dsv16x_spi2_int_ois_t;
 
 #define LSM6DSV16X_SPI2_CTRL1_OIS             0x70U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_read_en         : 1;
   uint8_t ois_g_en             : 1;
@@ -1934,8 +1805,7 @@ typedef struct
 } lsm6dsv16x_spi2_ctrl1_ois_t;
 
 #define LSM6DSV16X_SPI2_CTRL2_OIS             0x71U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_g_ois             : 3;
   uint8_t lpf1_g_ois_bw        : 2;
@@ -1948,8 +1818,7 @@ typedef struct
 } lsm6dsv16x_spi2_ctrl2_ois_t;
 
 #define LSM6DSV16X_SPI2_CTRL3_OIS             0x72U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_xl_ois            : 2;
   uint8_t not_used0            : 1;
@@ -1974,8 +1843,7 @@ typedef struct
   */
 
 #define LSM6DSV16X_PAGE_SEL                   0x2U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 4;
   uint8_t page_sel             : 4;
@@ -1986,8 +1854,7 @@ typedef struct
 } lsm6dsv16x_page_sel_t;
 
 #define LSM6DSV16X_EMB_FUNC_EN_A              0x4U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 1;
   uint8_t sflp_game_en         : 1;
@@ -2010,8 +1877,7 @@ typedef struct
 } lsm6dsv16x_emb_func_en_a_t;
 
 #define LSM6DSV16X_EMB_FUNC_EN_B              0x5U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_en               : 1;
   uint8_t not_used0            : 2;
@@ -2028,8 +1894,7 @@ typedef struct
 } lsm6dsv16x_emb_func_en_b_t;
 
 #define LSM6DSV16X_EMB_FUNC_EXEC_STATUS       0x7U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t emb_func_endop       : 1;
   uint8_t emb_func_exec_ovr    : 1;
@@ -2042,8 +1907,7 @@ typedef struct
 } lsm6dsv16x_emb_func_exec_status_t;
 
 #define LSM6DSV16X_PAGE_ADDRESS               0x8U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t page_addr            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2052,8 +1916,7 @@ typedef struct
 } lsm6dsv16x_page_address_t;
 
 #define LSM6DSV16X_PAGE_VALUE                 0x9U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t page_value           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2062,8 +1925,7 @@ typedef struct
 } lsm6dsv16x_page_value_t;
 
 #define LSM6DSV16X_EMB_FUNC_INT1              0x0AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t int1_step_detector   : 1;
@@ -2082,8 +1944,7 @@ typedef struct
 } lsm6dsv16x_emb_func_int1_t;
 
 #define LSM6DSV16X_FSM_INT1                   0x0BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int1_fsm1            : 1;
   uint8_t int1_fsm2            : 1;
@@ -2106,8 +1967,7 @@ typedef struct
 } lsm6dsv16x_fsm_int1_t;
 
 #define LSM6DSV16X_MLC_INT1                   0x0DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int1_mlc1            : 1;
   uint8_t int1_mlc2            : 1;
@@ -2124,8 +1984,7 @@ typedef struct
 } lsm6dsv16x_mlc_int1_t;
 
 #define LSM6DSV16X_EMB_FUNC_INT2              0x0EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t int2_step_detector   : 1;
@@ -2144,8 +2003,7 @@ typedef struct
 } lsm6dsv16x_emb_func_int2_t;
 
 #define LSM6DSV16X_FSM_INT2                   0x0FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_fsm1            : 1;
   uint8_t int2_fsm2            : 1;
@@ -2168,8 +2026,7 @@ typedef struct
 } lsm6dsv16x_fsm_int2_t;
 
 #define LSM6DSV16X_MLC_INT2                   0x11U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_mlc1            : 1;
   uint8_t int2_mlc2            : 1;
@@ -2186,8 +2043,7 @@ typedef struct
 } lsm6dsv16x_mlc_int2_t;
 
 #define LSM6DSV16X_EMB_FUNC_STATUS            0x12U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t is_step_det          : 1;
@@ -2206,8 +2062,7 @@ typedef struct
 } lsm6dsv16x_emb_func_status_t;
 
 #define LSM6DSV16X_FSM_STATUS                 0x13U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t is_fsm1              : 1;
   uint8_t is_fsm2              : 1;
@@ -2230,8 +2085,7 @@ typedef struct
 } lsm6dsv16x_fsm_status_t;
 
 #define LSM6DSV16X_MLC_STATUS                 0x15U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t is_mlc1              : 1;
   uint8_t is_mlc2              : 1;
@@ -2248,8 +2102,7 @@ typedef struct
 } lsm6dsv16x_mlc_status_t;
 
 #define LSM6DSV16X_PAGE_RW                    0x17U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 5;
   uint8_t page_read            : 1;
@@ -2264,8 +2117,7 @@ typedef struct
 } lsm6dsv16x_page_rw_t;
 
 #define LSM6DSV16X_EMB_FUNC_FIFO_EN_A         0x44U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 1;
   uint8_t sflp_game_fifo_en    : 1;
@@ -2286,8 +2138,7 @@ typedef struct
 } lsm6dsv16x_emb_func_fifo_en_a_t;
 
 #define LSM6DSV16X_EMB_FUNC_FIFO_EN_B         0x45U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0                     : 1;
   uint8_t mlc_filter_feature_fifo_en    : 1;
@@ -2300,8 +2151,7 @@ typedef struct
 } lsm6dsv16x_emb_func_fifo_en_b_t;
 
 #define LSM6DSV16X_FSM_ENABLE                 0x46U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm1_en              : 1;
   uint8_t fsm2_en              : 1;
@@ -2324,8 +2174,7 @@ typedef struct
 } lsm6dsv16x_fsm_enable_t;
 
 #define LSM6DSV16X_FSM_LONG_COUNTER_L         0x48U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_lc               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2334,8 +2183,7 @@ typedef struct
 } lsm6dsv16x_fsm_long_counter_l_t;
 
 #define LSM6DSV16X_FSM_LONG_COUNTER_H         0x49U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_lc               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2344,8 +2192,7 @@ typedef struct
 } lsm6dsv16x_fsm_long_counter_h_t;
 
 #define LSM6DSV16X_INT_ACK_MASK               0x4BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t iack_mask            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2354,8 +2201,7 @@ typedef struct
 } lsm6dsv16x_int_ack_mask_t;
 
 #define LSM6DSV16X_FSM_OUTS1                  0x4CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm1_n_v             : 1;
   uint8_t fsm1_p_v             : 1;
@@ -2378,8 +2224,7 @@ typedef struct
 } lsm6dsv16x_fsm_outs1_t;
 
 #define LSM6DSV16X_FSM_OUTS2                  0x4DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm2_n_v             : 1;
   uint8_t fsm2_p_v             : 1;
@@ -2402,8 +2247,7 @@ typedef struct
 } lsm6dsv16x_fsm_outs2_t;
 
 #define LSM6DSV16X_FSM_OUTS3                  0x4EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm3_n_v             : 1;
   uint8_t fsm3_p_v             : 1;
@@ -2426,8 +2270,7 @@ typedef struct
 } lsm6dsv16x_fsm_outs3_t;
 
 #define LSM6DSV16X_FSM_OUTS4                  0x4FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm4_n_v             : 1;
   uint8_t fsm4_p_v             : 1;
@@ -2450,8 +2293,7 @@ typedef struct
 } lsm6dsv16x_fsm_outs4_t;
 
 #define LSM6DSV16X_FSM_OUTS5                  0x50U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm5_n_v             : 1;
   uint8_t fsm5_p_v             : 1;
@@ -2474,8 +2316,7 @@ typedef struct
 } lsm6dsv16x_fsm_outs5_t;
 
 #define LSM6DSV16X_FSM_OUTS6                  0x51U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm6_n_v             : 1;
   uint8_t fsm6_p_v             : 1;
@@ -2498,8 +2339,7 @@ typedef struct
 } lsm6dsv16x_fsm_outs6_t;
 
 #define LSM6DSV16X_FSM_OUTS7                  0x52U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm7_n_v             : 1;
   uint8_t fsm7_p_v             : 1;
@@ -2522,8 +2362,7 @@ typedef struct
 } lsm6dsv16x_fsm_outs7_t;
 
 #define LSM6DSV16X_FSM_OUTS8                  0x53U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm8_n_v             : 1;
   uint8_t fsm8_p_v             : 1;
@@ -2546,8 +2385,7 @@ typedef struct
 } lsm6dsv16x_fsm_outs8_t;
 
 #define LSM6DSV16X_SFLP_ODR                   0x5EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t sflp_game_odr        : 3;
@@ -2560,8 +2398,7 @@ typedef struct
 } lsm6dsv16x_sflp_odr_t;
 
 #define LSM6DSV16X_FSM_ODR                    0x5FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t fsm_odr              : 3;
@@ -2574,8 +2411,7 @@ typedef struct
 } lsm6dsv16x_fsm_odr_t;
 
 #define LSM6DSV16X_MLC_ODR                    0x60U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 4;
   uint8_t mlc_odr              : 3;
@@ -2588,8 +2424,7 @@ typedef struct
 } lsm6dsv16x_mlc_odr_t;
 
 #define LSM6DSV16X_STEP_COUNTER_L             0x62U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t step                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2598,8 +2433,7 @@ typedef struct
 } lsm6dsv16x_step_counter_l_t;
 
 #define LSM6DSV16X_STEP_COUNTER_H             0x63U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t step                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2608,8 +2442,7 @@ typedef struct
 } lsm6dsv16x_step_counter_h_t;
 
 #define LSM6DSV16X_EMB_FUNC_SRC               0x64U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 2;
   uint8_t stepcounter_bit_set  : 1;
@@ -2630,8 +2463,7 @@ typedef struct
 } lsm6dsv16x_emb_func_src_t;
 
 #define LSM6DSV16X_EMB_FUNC_INIT_A            0x66U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 1;
   uint8_t sflp_game_init       : 1;
@@ -2654,8 +2486,7 @@ typedef struct
 } lsm6dsv16x_emb_func_init_a_t;
 
 #define LSM6DSV16X_EMB_FUNC_INIT_B            0x67U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_init             : 1;
   uint8_t not_used0            : 2;
@@ -2672,8 +2503,7 @@ typedef struct
 } lsm6dsv16x_emb_func_init_b_t;
 
 #define LSM6DSV16X_MLC1_SRC                   0x70U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc1_src             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2682,8 +2512,7 @@ typedef struct
 } lsm6dsv16x_mlc1_src_t;
 
 #define LSM6DSV16X_MLC2_SRC                   0x71U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc2_src             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2692,8 +2521,7 @@ typedef struct
 } lsm6dsv16x_mlc2_src_t;
 
 #define LSM6DSV16X_MLC3_SRC                   0x72U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc3_src             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2702,8 +2530,7 @@ typedef struct
 } lsm6dsv16x_mlc3_src_t;
 
 #define LSM6DSV16X_MLC4_SRC                   0x73U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc4_src             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2723,8 +2550,7 @@ typedef struct
 #define LSM6DSV16X_EMB_ADV_PG_0              0x000U
 
 #define LSM6DSV16X_SFLP_GAME_GBIASX_L        0x6EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasx               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2733,8 +2559,7 @@ typedef struct
 } lsm6dsv16x_sflp_game_gbiasx_l_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASX_H        0x6FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasx               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2743,8 +2568,7 @@ typedef struct
 } lsm6dsv16x_sflp_game_gbiasx_h_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASY_L        0x70U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasy               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2753,8 +2577,7 @@ typedef struct
 } lsm6dsv16x_sflp_game_gbiasy_l_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASY_H        0x71U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasy               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2763,8 +2586,7 @@ typedef struct
 } lsm6dsv16x_sflp_game_gbiasy_h_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASZ_L        0x72U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasz               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2773,8 +2595,7 @@ typedef struct
 } lsm6dsv16x_sflp_game_gbiasz_l_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASZ_H        0x73U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasz               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2783,8 +2604,7 @@ typedef struct
 } lsm6dsv16x_sflp_game_gbiasz_h_t;
 
 #define LSM6DSV16X_FSM_EXT_SENSITIVITY_L     0xBAU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_s            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2793,8 +2613,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_sensitivity_l_t;
 
 #define LSM6DSV16X_FSM_EXT_SENSITIVITY_H     0xBBU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_s            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2803,8 +2622,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_sensitivity_h_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFX_L            0xC0U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offx         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2813,8 +2631,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_offx_l_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFX_H            0xC1U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offx         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2823,8 +2640,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_offx_h_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFY_L            0xC2U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offy         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2833,8 +2649,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_offy_l_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFY_H            0xC3U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offy         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2843,8 +2658,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_offy_h_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFZ_L            0xC4U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offz         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2853,8 +2667,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_offz_l_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFZ_H            0xC5U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offz         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2863,8 +2676,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_offz_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XX_L       0xC6U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xx       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2873,8 +2685,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_xx_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XX_H       0xC7U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xx       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2883,8 +2694,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_xx_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XY_L       0xC8U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xy       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2893,8 +2703,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_xy_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XY_H       0xC9U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xy       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2903,8 +2712,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_xy_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XZ_L       0xCAU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2913,8 +2721,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_xz_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XZ_H       0xCBU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2923,8 +2730,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_xz_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_YY_L       0xCCU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_yy       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2933,8 +2739,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_yy_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_YY_H       0xCDU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_yy       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2943,8 +2748,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_yy_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_YZ_L       0xCEU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_yz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2953,8 +2757,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_yz_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_YZ_H       0xCFU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_yz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2963,8 +2766,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_yz_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_ZZ_L       0xD0U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_zz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2973,8 +2775,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_zz_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_ZZ_H       0xD1U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_zz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2983,8 +2784,7 @@ typedef struct
 } lsm6dsv16x_fsm_ext_matrix_zz_h_t;
 
 #define LSM6DSV16X_EXT_CFG_A                 0xD4U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_z_axis           : 3;
   uint8_t not_used0            : 1;
@@ -2999,8 +2799,7 @@ typedef struct
 } lsm6dsv16x_ext_cfg_a_t;
 
 #define LSM6DSV16X_EXT_CFG_B                 0xD5U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_x_axis           : 3;
   uint8_t not_used0            : 5;
@@ -3022,8 +2821,7 @@ typedef struct
 #define LSM6DSV16X_EMB_ADV_PG_1             0x100U
 
 #define LSM6DSV16X_FSM_LC_TIMEOUT_L         0x7AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_lc_timeout       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3032,8 +2830,7 @@ typedef struct
 } lsm6dsv16x_fsm_lc_timeout_l_t;
 
 #define LSM6DSV16X_FSM_LC_TIMEOUT_H         0x7BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_lc_timeout       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3042,8 +2839,7 @@ typedef struct
 } lsm6dsv16x_fsm_lc_timeout_h_t;
 
 #define LSM6DSV16X_FSM_PROGRAMS             0x7CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_n_prog           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3052,8 +2848,7 @@ typedef struct
 } lsm6dsv16x_fsm_programs_t;
 
 #define LSM6DSV16X_FSM_START_ADD_L          0x7EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_start            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3062,8 +2857,7 @@ typedef struct
 } lsm6dsv16x_fsm_start_add_l_t;
 
 #define LSM6DSV16X_FSM_START_ADD_H          0x7FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_start            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3072,8 +2866,7 @@ typedef struct
 } lsm6dsv16x_fsm_start_add_h_t;
 
 #define LSM6DSV16X_PEDO_CMD_REG             0x83U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 2;
   uint8_t fp_rejection_en      : 1;
@@ -3088,8 +2881,7 @@ typedef struct
 } lsm6dsv16x_pedo_cmd_reg_t;
 
 #define LSM6DSV16X_PEDO_DEB_STEPS_CONF      0x84U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t deb_step             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3098,8 +2890,7 @@ typedef struct
 } lsm6dsv16x_pedo_deb_steps_conf_t;
 
 #define LSM6DSV16X_PEDO_SC_DELTAT_L         0xD0U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t pd_sc                : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3108,8 +2899,7 @@ typedef struct
 } lsm6dsv16x_pedo_sc_deltat_l_t;
 
 #define LSM6DSV16X_PEDO_SC_DELTAT_H         0xD1U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t pd_sc                : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3118,8 +2908,7 @@ typedef struct
 } lsm6dsv16x_pedo_sc_deltat_h_t;
 
 #define LSM6DSV16X_MLC_EXT_SENSITIVITY_L    0xE8U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc_ext_s            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3128,8 +2917,7 @@ typedef struct
 } lsm6dsv16x_mlc_ext_sensitivity_l_t;
 
 #define LSM6DSV16X_MLC_EXT_SENSITIVITY_H    0xE9U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc_ext_s            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3144,8 +2932,7 @@ typedef struct
 #define LSM6DSV16X_EMB_ADV_PG_2             0x200U
 
 #define LSM6DSV16X_EXT_FORMAT               0x00
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 2;
   uint8_t ext_format_sel       : 1;
@@ -3158,8 +2945,7 @@ typedef struct
 } lsm6dsv16x_ext_format_t;
 
 #define LSM6DSV16X_EXT_3BYTE_SENSITIVITY_L  0x02U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_s          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3168,8 +2954,7 @@ typedef struct
 } lsm6dsv16x_ext_3byte_sensitivity_l_t;
 
 #define LSM6DSV16X_EXT_3BYTE_SENSITIVITY_H  0x03U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_s          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3178,8 +2963,7 @@ typedef struct
 } lsm6dsv16x_ext_3byte_sensitivity_h_t;
 
 #define LSM6DSV16X_EXT_3BYTE_OFFSET_XL      0x06U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_off        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3188,8 +2972,7 @@ typedef struct
 } lsm6dsv16x_ext_3byte_offset_xl_t;
 
 #define LSM6DSV16X_EXT_3BYTE_OFFSET_L       0x07U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_off        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3198,8 +2981,7 @@ typedef struct
 } lsm6dsv16x_ext_3byte_offset_l_t;
 
 #define LSM6DSV16X_EXT_3BYTE_OFFSET_H       0x08U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_off        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3218,8 +3000,7 @@ typedef struct
   */
 
 #define LSM6DSV16X_SENSOR_HUB_1             0x2U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub1           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3228,8 +3009,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_1_t;
 
 #define LSM6DSV16X_SENSOR_HUB_2             0x3U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub2           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3238,8 +3018,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_2_t;
 
 #define LSM6DSV16X_SENSOR_HUB_3             0x4U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub3           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3248,8 +3027,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_3_t;
 
 #define LSM6DSV16X_SENSOR_HUB_4             0x5U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub4           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3258,8 +3036,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_4_t;
 
 #define LSM6DSV16X_SENSOR_HUB_5             0x6U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub5           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3268,8 +3045,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_5_t;
 
 #define LSM6DSV16X_SENSOR_HUB_6             0x7U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub6           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3278,8 +3054,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_6_t;
 
 #define LSM6DSV16X_SENSOR_HUB_7             0x8U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub7           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3288,8 +3063,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_7_t;
 
 #define LSM6DSV16X_SENSOR_HUB_8             0x9U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub8           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3298,8 +3072,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_8_t;
 
 #define LSM6DSV16X_SENSOR_HUB_9             0x0AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub9           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3308,8 +3081,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_9_t;
 
 #define LSM6DSV16X_SENSOR_HUB_10            0x0BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub10          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3318,8 +3090,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_10_t;
 
 #define LSM6DSV16X_SENSOR_HUB_11            0x0CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub11          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3328,8 +3099,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_11_t;
 
 #define LSM6DSV16X_SENSOR_HUB_12            0x0DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub12          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3338,8 +3108,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_12_t;
 
 #define LSM6DSV16X_SENSOR_HUB_13            0x0EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub13          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3348,8 +3117,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_13_t;
 
 #define LSM6DSV16X_SENSOR_HUB_14            0x0FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub14          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3358,8 +3126,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_14_t;
 
 #define LSM6DSV16X_SENSOR_HUB_15            0x10U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub15          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3368,8 +3135,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_15_t;
 
 #define LSM6DSV16X_SENSOR_HUB_16            0x11U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub16          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3378,8 +3144,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_16_t;
 
 #define LSM6DSV16X_SENSOR_HUB_17            0x12U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub17          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3388,8 +3153,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_17_t;
 
 #define LSM6DSV16X_SENSOR_HUB_18            0x13U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub18          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3398,8 +3162,7 @@ typedef struct
 } lsm6dsv16x_sensor_hub_18_t;
 
 #define LSM6DSV16X_MASTER_CONFIG            0x14U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t aux_sens_on          : 2;
   uint8_t master_on            : 1;
@@ -3420,8 +3183,7 @@ typedef struct
 } lsm6dsv16x_master_config_t;
 
 #define LSM6DSV16X_SLV0_ADD                 0x15U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t rw_0                 : 1;
   uint8_t slave0_add           : 7;
@@ -3432,8 +3194,7 @@ typedef struct
 } lsm6dsv16x_slv0_add_t;
 
 #define LSM6DSV16X_SLV0_SUBADD              0x16U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave0_reg           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3442,8 +3203,7 @@ typedef struct
 } lsm6dsv16x_slv0_subadd_t;
 
 #define LSM6DSV16X_SLV0_CONFIG              0x17U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave0_numop         : 3;
   uint8_t batch_ext_sens_0_en  : 1;
@@ -3458,8 +3218,7 @@ typedef struct
 } lsm6dsv16x_slv0_config_t;
 
 #define LSM6DSV16X_SLV1_ADD                 0x18U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t r_1                  : 1;
   uint8_t slave1_add           : 7;
@@ -3470,8 +3229,7 @@ typedef struct
 } lsm6dsv16x_slv1_add_t;
 
 #define LSM6DSV16X_SLV1_SUBADD              0x19U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave1_reg           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3480,8 +3238,7 @@ typedef struct
 } lsm6dsv16x_slv1_subadd_t;
 
 #define LSM6DSV16X_SLV1_CONFIG              0x1AU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave1_numop         : 3;
   uint8_t batch_ext_sens_1_en  : 1;
@@ -3494,8 +3251,7 @@ typedef struct
 } lsm6dsv16x_slv1_config_t;
 
 #define LSM6DSV16X_SLV2_ADD                 0x1BU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t r_2                  : 1;
   uint8_t slave2_add           : 7;
@@ -3506,8 +3262,7 @@ typedef struct
 } lsm6dsv16x_slv2_add_t;
 
 #define LSM6DSV16X_SLV2_SUBADD              0x1CU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave2_reg           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3516,8 +3271,7 @@ typedef struct
 } lsm6dsv16x_slv2_subadd_t;
 
 #define LSM6DSV16X_SLV2_CONFIG              0x1DU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave2_numop         : 3;
   uint8_t batch_ext_sens_2_en  : 1;
@@ -3530,8 +3284,7 @@ typedef struct
 } lsm6dsv16x_slv2_config_t;
 
 #define LSM6DSV16X_SLV3_ADD                 0x1EU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t r_3                  : 1;
   uint8_t slave3_add           : 7;
@@ -3542,8 +3295,7 @@ typedef struct
 } lsm6dsv16x_slv3_add_t;
 
 #define LSM6DSV16X_SLV3_SUBADD              0x1FU
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave3_reg           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3552,8 +3304,7 @@ typedef struct
 } lsm6dsv16x_slv3_subadd_t;
 
 #define LSM6DSV16X_SLV3_CONFIG              0x20U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave3_numop         : 3;
   uint8_t batch_ext_sens_3_en  : 1;
@@ -3566,8 +3317,7 @@ typedef struct
 } lsm6dsv16x_slv3_config_t;
 
 #define LSM6DSV16X_DATAWRITE_SLV0           0x21U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave0_dataw         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3576,8 +3326,7 @@ typedef struct
 } lsm6dsv16x_datawrite_slv0_t;
 
 #define LSM6DSV16X_STATUS_MASTER            0x22U
-typedef struct
-{
+typedef struct {
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sens_hub_endop       : 1;
   uint8_t not_used0            : 2;
@@ -3614,8 +3363,7 @@ typedef struct
   * @{
   *
   */
-typedef union
-{
+typedef union {
   lsm6dsv16x_func_cfg_access_t          func_cfg_access;
   lsm6dsv16x_pin_ctrl_t                 pin_ctrl;
   lsm6dsv16x_if_cfg_t                   if_cfg;
@@ -3901,8 +3649,7 @@ float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb);
 int32_t lsm6dsv16x_xl_offset_on_out_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_xl_offset_on_out_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
+typedef struct {
   float_t z_mg;
   float_t y_mg;
   float_t x_mg;
@@ -3912,8 +3659,7 @@ int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_xl_offset_mg_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_READY             = 0x0,
   LSM6DSV16X_GLOBAL_RST        = 0x1,
   LSM6DSV16X_RESTORE_CAL_PARAM = 0x2,
@@ -3922,8 +3668,7 @@ typedef enum
 int32_t lsm6dsv16x_reset_set(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val);
 int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_MAIN_MEM_BANK       = 0x0,
   LSM6DSV16X_EMBED_FUNC_MEM_BANK = 0x1,
   LSM6DSV16X_SENSOR_HUB_MEM_BANK = 0x2,
@@ -3933,8 +3678,7 @@ int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val);
 
 int32_t lsm6dsv16x_device_id_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_ODR_OFF              = 0x0,
   LSM6DSV16X_ODR_AT_1Hz875        = 0x1,
   LSM6DSV16X_ODR_AT_7Hz5          = 0x2,
@@ -3979,8 +3723,7 @@ int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val);
 
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_XL_HIGH_PERFORMANCE_MD   = 0x0,
   LSM6DSV16X_XL_HIGH_ACCURACY_ODR_MD = 0x1,
   LSM6DSV16X_XL_ODR_TRIGGERED_MD      = 0x3,
@@ -3992,8 +3735,7 @@ typedef enum
 int32_t lsm6dsv16x_xl_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t val);
 int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_GY_HIGH_PERFORMANCE_MD   = 0x0,
   LSM6DSV16X_GY_HIGH_ACCURACY_ODR_MD = 0x1,
   LSM6DSV16X_GY_SLEEP_MD              = 0x4,
@@ -4011,8 +3753,7 @@ int32_t lsm6dsv16x_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsv16x_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_odr_trig_cfg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_DRDY_LATCHED = 0x0,
   LSM6DSV16X_DRDY_PULSED  = 0x1,
 } lsm6dsv16x_data_ready_mode_t;
@@ -4021,8 +3762,7 @@ int32_t lsm6dsv16x_data_ready_mode_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_data_ready_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t enable               : 1; /* interrupt enable */
   uint8_t lir                  : 1; /* interrupt pulsed or latched */
 } lsm6dsv16x_interrupt_mode_t;
@@ -4031,8 +3771,7 @@ int32_t lsm6dsv16x_interrupt_enable_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_interrupt_enable_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_125dps  = 0x0,
   LSM6DSV16X_250dps  = 0x1,
   LSM6DSV16X_500dps  = 0x2,
@@ -4045,8 +3784,7 @@ int32_t lsm6dsv16x_gy_full_scale_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_2g  = 0x0,
   LSM6DSV16X_4g  = 0x1,
   LSM6DSV16X_8g  = 0x2,
@@ -4060,8 +3798,7 @@ int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_xl_dual_channel_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_xl_dual_channel_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_XL_ST_DISABLE  = 0x0,
   LSM6DSV16X_XL_ST_POSITIVE = 0x1,
   LSM6DSV16X_XL_ST_NEGATIVE = 0x2,
@@ -4071,8 +3808,7 @@ int32_t lsm6dsv16x_xl_self_test_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_OIS_XL_ST_DISABLE  = 0x0,
   LSM6DSV16X_OIS_XL_ST_POSITIVE = 0x1,
   LSM6DSV16X_OIS_XL_ST_NEGATIVE = 0x2,
@@ -4082,8 +3818,7 @@ int32_t lsm6dsv16x_ois_xl_self_test_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_GY_ST_DISABLE  = 0x0,
   LSM6DSV16X_GY_ST_POSITIVE = 0x1,
   LSM6DSV16X_GY_ST_NEGATIVE = 0x2,
@@ -4094,8 +3829,7 @@ int32_t lsm6dsv16x_gy_self_test_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_OIS_GY_ST_DISABLE   = 0x0,
   LSM6DSV16X_OIS_GY_ST_POSITIVE  = 0x1,
   LSM6DSV16X_OIS_GY_ST_NEGATIVE  = 0x2,
@@ -4108,8 +3842,7 @@ int32_t lsm6dsv16x_ois_gy_self_test_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t drdy_xl              : 1;
   uint8_t drdy_gy              : 1;
   uint8_t drdy_temp            : 1;
@@ -4173,8 +3906,7 @@ typedef struct
 int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_all_sources_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t drdy_xl              : 1;
   uint8_t drdy_g               : 1;
   uint8_t drdy_g_eis           : 1;
@@ -4202,8 +3934,7 @@ int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t drdy_xl              : 1;
   uint8_t drdy_gy              : 1;
   uint8_t drdy_temp            : 1;
@@ -4242,8 +3973,7 @@ int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
 int32_t lsm6dsv16x_emb_function_dbg_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_DEN_ACT_LOW  = 0x0,
   LSM6DSV16X_DEN_ACT_HIGH = 0x1,
 } lsm6dsv16x_den_polarity_t;
@@ -4252,15 +3982,13 @@ int32_t lsm6dsv16x_den_polarity_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t stamp_in_gy_data     : 1;
   uint8_t stamp_in_xl_data     : 1;
   uint8_t den_x                : 1;
   uint8_t den_y                : 1;
   uint8_t den_z                : 1;
-  enum
-  {
+  enum {
     DEN_NOT_DEFINED = 0x00,
     LEVEL_TRIGGER   = 0x02,
     LEVEL_LATCHED   = 0x03,
@@ -4269,8 +3997,7 @@ typedef struct
 int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val);
 int32_t lsm6dsv16x_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_EIS_125dps  = 0x0,
   LSM6DSV16X_EIS_250dps  = 0x1,
   LSM6DSV16X_EIS_500dps  = 0x2,
@@ -4285,8 +4012,7 @@ int32_t lsm6dsv16x_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_eis_gy_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_eis_gy_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_EIS_ODR_OFF = 0x0,
   LSM6DSV16X_EIS_1920Hz  = 0x1,
   LSM6DSV16X_EIS_960Hz   = 0x2,
@@ -4302,8 +4028,7 @@ int32_t lsm6dsv16x_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_CMP_DISABLE = 0x0,
   LSM6DSV16X_CMP_8_TO_1  = 0x1,
   LSM6DSV16X_CMP_16_TO_1 = 0x2,
@@ -4327,8 +4052,7 @@ int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_XL_NOT_BATCHED       = 0x0,
   LSM6DSV16X_XL_BATCHED_AT_1Hz875 = 0x1,
   LSM6DSV16X_XL_BATCHED_AT_7Hz5   = 0x2,
@@ -4348,8 +4072,7 @@ int32_t lsm6dsv16x_fifo_xl_batch_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_GY_NOT_BATCHED       = 0x0,
   LSM6DSV16X_GY_BATCHED_AT_1Hz875 = 0x1,
   LSM6DSV16X_GY_BATCHED_AT_7Hz5   = 0x2,
@@ -4369,8 +4092,7 @@ int32_t lsm6dsv16x_fifo_gy_batch_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_BYPASS_MODE             = 0x0,
   LSM6DSV16X_FIFO_MODE               = 0x1,
   LSM6DSV16X_STREAM_WTM_TO_FULL_MODE = 0x2,
@@ -4386,8 +4108,7 @@ int32_t lsm6dsv16x_fifo_mode_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fifo_gy_eis_batch_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_fifo_gy_eis_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_TEMP_NOT_BATCHED       = 0x0,
   LSM6DSV16X_TEMP_BATCHED_AT_1Hz875 = 0x1,
   LSM6DSV16X_TEMP_BATCHED_AT_15Hz   = 0x2,
@@ -4398,8 +4119,7 @@ int32_t lsm6dsv16x_fifo_temp_batch_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fifo_temp_batch_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_TMSTMP_NOT_BATCHED = 0x0,
   LSM6DSV16X_TMSTMP_DEC_1       = 0x1,
   LSM6DSV16X_TMSTMP_DEC_8       = 0x2,
@@ -4415,8 +4135,7 @@ int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
                                                     uint16_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_XL_BATCH_EVENT     = 0x0,
   LSM6DSV16X_GY_BATCH_EVENT     = 0x1,
   LSM6DSV16X_GY_EIS_BATCH_EVENT = 0x2,
@@ -4426,8 +4145,7 @@ int32_t lsm6dsv16x_fifo_batch_cnt_event_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t *val);
 
-typedef struct
-{
+typedef struct {
   uint16_t fifo_level          : 9;
   uint8_t fifo_bdr             : 1;
   uint8_t fifo_full            : 1;
@@ -4438,10 +4156,8 @@ typedef struct
 int32_t lsm6dsv16x_fifo_status_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_fifo_status_t *val);
 
-typedef struct
-{
-  enum
-  {
+typedef struct {
+  enum {
     LSM6DSV16X_FIFO_EMPTY                    = 0x0,
     LSM6DSV16X_GY_NC_TAG                     = 0x1,
     LSM6DSV16X_XL_NC_TAG                     = 0x2,
@@ -4489,8 +4205,7 @@ int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val);
 int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t game_rotation        : 1;
   uint8_t gravity              : 1;
   uint8_t gbias                : 1;
@@ -4500,8 +4215,7 @@ int32_t lsm6dsv16x_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_AUTO          = 0x0,
   LSM6DSV16X_ALWAYS_ACTIVE = 0x1,
 } lsm6dsv16x_filt_anti_spike_t;
@@ -4510,8 +4224,7 @@ int32_t lsm6dsv16x_filt_anti_spike_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t drdy                 : 1;
   uint8_t ois_drdy             : 1;
   uint8_t irq_xl               : 1;
@@ -4522,8 +4235,7 @@ int32_t lsm6dsv16x_filt_settling_mask_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_settling_mask_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t ois_drdy             : 1;
 } lsm6dsv16x_filt_ois_settling_mask_t;
 int32_t lsm6dsv16x_filt_ois_settling_mask_set(stmdev_ctx_t *ctx,
@@ -4531,8 +4243,7 @@ int32_t lsm6dsv16x_filt_ois_settling_mask_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_ois_settling_mask_get(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_GY_ULTRA_LIGHT   = 0x0,
   LSM6DSV16X_GY_VERY_LIGHT    = 0x1,
   LSM6DSV16X_GY_LIGHT         = 0x2,
@@ -4550,8 +4261,7 @@ int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_gy_lp1_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_filt_gy_lp1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_XL_ULTRA_LIGHT = 0x0,
   LSM6DSV16X_XL_VERY_LIGHT  = 0x1,
   LSM6DSV16X_XL_LIGHT       = 0x2,
@@ -4575,8 +4285,7 @@ int32_t lsm6dsv16x_filt_xl_hp_get(stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsv16x_filt_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_filt_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_HP_MD_NORMAL    = 0x0,
   LSM6DSV16X_HP_MD_REFERENCE = 0x1,
 } lsm6dsv16x_filt_xl_hp_mode_t;
@@ -4585,8 +4294,7 @@ int32_t lsm6dsv16x_filt_xl_hp_mode_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_WK_FEED_SLOPE          = 0x0,
   LSM6DSV16X_WK_FEED_HIGH_PASS      = 0x1,
   LSM6DSV16X_WK_FEED_LP_WITH_OFFSET = 0x2,
@@ -4599,8 +4307,7 @@ int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_mask_trigger_xl_settl_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_mask_trigger_xl_settl_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SIXD_FEED_ODR_DIV_2 = 0x0,
   LSM6DSV16X_SIXD_FEED_LOW_PASS  = 0x1,
 } lsm6dsv16x_filt_sixd_feed_t;
@@ -4609,8 +4316,7 @@ int32_t lsm6dsv16x_filt_sixd_feed_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_EIS_LP_NORMAL = 0x0,
   LSM6DSV16X_EIS_LP_LIGHT  = 0x1,
 } lsm6dsv16x_filt_gy_eis_lp_bandwidth_t;
@@ -4619,8 +4325,7 @@ int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_OIS_GY_LP_NORMAL     = 0x0,
   LSM6DSV16X_OIS_GY_LP_STRONG     = 0x1,
   LSM6DSV16X_OIS_GY_LP_AGGRESSIVE = 0x2,
@@ -4631,8 +4336,7 @@ int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_OIS_XL_LP_ULTRA_LIGHT = 0x0,
   LSM6DSV16X_OIS_XL_LP_VERY_LIGHT  = 0x1,
   LSM6DSV16X_OIS_XL_LP_LIGHT       = 0x2,
@@ -4647,8 +4351,7 @@ int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_PROTECT_CTRL_REGS = 0x0,
   LSM6DSV16X_WRITE_CTRL_REG    = 0x1,
 } lsm6dsv16x_fsm_permission_t;
@@ -4658,8 +4361,7 @@ int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t *val);
 int32_t lsm6dsv16x_fsm_permission_status(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t fsm1_en              : 1;
   uint8_t fsm2_en              : 1;
   uint8_t fsm3_en              : 1;
@@ -4676,8 +4378,7 @@ int32_t lsm6dsv16x_fsm_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val);
 int32_t lsm6dsv16x_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val);
 
 
-typedef struct
-{
+typedef struct {
   uint8_t fsm_outs1;
   uint8_t fsm_outs2;
   uint8_t fsm_outs3;
@@ -4689,8 +4390,7 @@ typedef struct
 } lsm6dsv16x_fsm_out_t;
 int32_t lsm6dsv16x_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_FSM_15Hz  = 0x0,
   LSM6DSV16X_FSM_30Hz  = 0x1,
   LSM6DSV16X_FSM_60Hz  = 0x2,
@@ -4709,8 +4409,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
                                                 uint16_t *val);
 
-typedef struct
-{
+typedef struct {
   uint16_t z;
   uint16_t y;
   uint16_t x;
@@ -4720,8 +4419,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_offset_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t *val);
 
-typedef struct
-{
+typedef struct {
   uint16_t xx;
   uint16_t xy;
   uint16_t xz;
@@ -4734,8 +4432,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_Z_EQ_Y     = 0x0,
   LSM6DSV16X_Z_EQ_MIN_Y = 0x1,
   LSM6DSV16X_Z_EQ_X     = 0x2,
@@ -4748,8 +4445,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_Y_EQ_Y     = 0x0,
   LSM6DSV16X_Y_EQ_MIN_Y = 0x1,
   LSM6DSV16X_Y_EQ_X     = 0x2,
@@ -4762,8 +4458,7 @@ int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_X_EQ_Y     = 0x0,
   LSM6DSV16X_X_EQ_MIN_Y = 0x1,
   LSM6DSV16X_X_EQ_X     = 0x2,
@@ -4788,8 +4483,7 @@ int32_t lsm6dsv16x_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val);
 int32_t lsm6dsv16x_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_ff_time_windows_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_156_mg = 0x0,
   LSM6DSV16X_219_mg = 0x1,
   LSM6DSV16X_250_mg = 0x2,
@@ -4804,8 +4498,7 @@ int32_t lsm6dsv16x_ff_thresholds_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_MLC_OFF                             = 0x0,
   LSM6DSV16X_MLC_ON                              = 0x1,
   LSM6DSV16X_MLC_ON_BEFORE_FSM                   = 0x2,
@@ -4813,8 +4506,7 @@ typedef enum
 int32_t lsm6dsv16x_mlc_set(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val);
 int32_t lsm6dsv16x_mlc_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_MLC_15Hz  = 0x0,
   LSM6DSV16X_MLC_30Hz  = 0x1,
   LSM6DSV16X_MLC_60Hz  = 0x2,
@@ -4828,8 +4520,7 @@ int32_t lsm6dsv16x_mlc_data_rate_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t mlc1_src;
   uint8_t mlc2_src;
   uint8_t mlc3_src;
@@ -4842,8 +4533,7 @@ int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
                                                 uint16_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_OIS_CTRL_FROM_OIS = 0x0,
   LSM6DSV16X_OIS_CTRL_FROM_UI  = 0x1,
 } lsm6dsv16x_ois_ctrl_mode_t;
@@ -4858,8 +4548,7 @@ int32_t lsm6dsv16x_ois_reset_get(stmdev_ctx_t *ctx, int8_t *val);
 int32_t lsm6dsv16x_ois_interface_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_ois_interface_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t ack                  : 1;
   uint8_t req                  : 1;
 } lsm6dsv16x_ois_handshake_t;
@@ -4878,8 +4567,7 @@ int32_t lsm6dsv16x_ois_shared_get(stmdev_ctx_t *ctx, uint8_t val[6]);
 int32_t lsm6dsv16x_ois_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_ois_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t gy                   : 1;
   uint8_t xl                   : 1;
 } lsm6dsv16x_ois_chain_t;
@@ -4887,8 +4575,7 @@ int32_t lsm6dsv16x_ois_chain_set(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t val);
 int32_t lsm6dsv16x_ois_chain_get(stmdev_ctx_t *ctx,
                                  lsm6dsv16x_ois_chain_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_OIS_125dps  = 0x0,
   LSM6DSV16X_OIS_250dps  = 0x1,
   LSM6DSV16X_OIS_500dps  = 0x2,
@@ -4900,8 +4587,7 @@ int32_t lsm6dsv16x_ois_gy_full_scale_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_OIS_2g  = 0x0,
   LSM6DSV16X_OIS_4g  = 0x1,
   LSM6DSV16X_OIS_8g  = 0x2,
@@ -4912,8 +4598,7 @@ int32_t lsm6dsv16x_ois_xl_full_scale_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_DEG_80 = 0x0,
   LSM6DSV16X_DEG_70 = 0x1,
   LSM6DSV16X_DEG_60 = 0x2,
@@ -4927,8 +4612,7 @@ int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_2400MOhm = 0x0,
   LSM6DSV16X_730MOhm = 0x1,
   LSM6DSV16X_300MOhm = 0x2,
@@ -4939,8 +4623,7 @@ int32_t lsm6dsv16x_ah_qvar_zin_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t ah_qvar_en           : 1;
 } lsm6dsv16x_ah_qvar_mode_t;
 int32_t lsm6dsv16x_ah_qvar_mode_set(stmdev_ctx_t *ctx,
@@ -4948,8 +4631,7 @@ int32_t lsm6dsv16x_ah_qvar_mode_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ah_qvar_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SW_RST_DYN_ADDRESS_RST = 0x0,
   LSM6DSV16X_I3C_GLOBAL_RST         = 0x1,
 } lsm6dsv16x_i3c_reset_mode_t;
@@ -4958,8 +4640,7 @@ int32_t lsm6dsv16x_i3c_reset_mode_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_IBI_2us  = 0x0,
   LSM6DSV16X_IBI_50us = 0x1,
   LSM6DSV16X_IBI_1ms  = 0x2,
@@ -4978,8 +4659,7 @@ int32_t lsm6dsv16x_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                         uint8_t len);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SLV_0       = 0x0,
   LSM6DSV16X_SLV_0_1     = 0x1,
   LSM6DSV16X_SLV_0_1_2   = 0x2,
@@ -4996,8 +4676,7 @@ int32_t lsm6dsv16x_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 int32_t lsm6dsv16x_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SH_TRG_XL_GY_DRDY = 0x0,
   LSM6DSV16X_SH_TRIG_INT2      = 0x1,
 } lsm6dsv16x_sh_syncro_mode_t;
@@ -5006,8 +4685,7 @@ int32_t lsm6dsv16x_sh_syncro_mode_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_EACH_SH_CYCLE    = 0x0,
   LSM6DSV16X_ONLY_FIRST_CYCLE = 0x1,
 } lsm6dsv16x_sh_write_mode_t;
@@ -5019,16 +4697,14 @@ int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t   slv0_add;
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } lsm6dsv16x_sh_cfg_write_t;
 int32_t lsm6dsv16x_sh_cfg_write(stmdev_ctx_t *ctx,
                                 lsm6dsv16x_sh_cfg_write_t *val);
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SH_15Hz  = 0x1,
   LSM6DSV16X_SH_30Hz  = 0x2,
   LSM6DSV16X_SH_60Hz  = 0x3,
@@ -5041,8 +4717,7 @@ int32_t lsm6dsv16x_sh_data_rate_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_len;
@@ -5056,8 +4731,7 @@ int32_t lsm6dsv16x_sh_status_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_ui_sdo_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_I2C_I3C_ENABLE  = 0x0,
   LSM6DSV16X_I2C_I3C_DISABLE = 0x1,
 } lsm6dsv16x_ui_i2c_i3c_mode_t;
@@ -5066,8 +4740,7 @@ int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SPI_4_WIRE = 0x0,
   LSM6DSV16X_SPI_3_WIRE = 0x1,
 } lsm6dsv16x_spi_mode_t;
@@ -5077,8 +4750,7 @@ int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val);
 int32_t lsm6dsv16x_ui_sda_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_ui_sda_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SPI2_4_WIRE = 0x0,
   LSM6DSV16X_SPI2_3_WIRE = 0x1,
 } lsm6dsv16x_spi2_mode_t;
@@ -5089,8 +4761,7 @@ int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t step_counter_enable  : 1;
   uint8_t false_step_rej       : 1;
 } lsm6dsv16x_stpcnt_mode_t;
@@ -5113,8 +4784,7 @@ int32_t lsm6dsv16x_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val);
 int32_t lsm6dsv16x_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct
-{
+typedef struct {
   float_t gbias_x; /* dps */
   float_t gbias_y; /* dps */
   float_t gbias_z; /* dps */
@@ -5122,8 +4792,7 @@ typedef struct
 int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_sflp_gbias_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SFLP_15Hz  = 0x0,
   LSM6DSV16X_SFLP_30Hz  = 0x1,
   LSM6DSV16X_SFLP_60Hz  = 0x2,
@@ -5136,8 +4805,7 @@ int32_t lsm6dsv16x_sflp_data_rate_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t tap_x_en             : 1;
   uint8_t tap_y_en             : 1;
   uint8_t tap_z_en             : 1;
@@ -5147,8 +4815,7 @@ int32_t lsm6dsv16x_tap_detection_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_tap_detection_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t x                    : 5;
   uint8_t y                    : 5;
   uint8_t z                    : 5;
@@ -5158,8 +4825,7 @@ int32_t lsm6dsv16x_tap_thresholds_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_tap_thresholds_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_XYZ  = 0x0,
   LSM6DSV16X_YXZ  = 0x1,
   LSM6DSV16X_XZY  = 0x2,
@@ -5172,8 +4838,7 @@ int32_t lsm6dsv16x_tap_axis_priority_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t shock                : 2;
   uint8_t quiet                : 2;
   uint8_t tap_gap              : 4;
@@ -5183,8 +4848,7 @@ int32_t lsm6dsv16x_tap_time_windows_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_tap_time_windows_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_ONLY_SINGLE        = 0x0,
   LSM6DSV16X_BOTH_SINGLE_DOUBLE = 0x1,
 } lsm6dsv16x_tap_mode_t;
@@ -5199,8 +4863,7 @@ int32_t lsm6dsv16x_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val);
 int32_t lsm6dsv16x_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
 int32_t lsm6dsv16x_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_XL_AND_GY_NOT_AFFECTED       = 0x0,
   LSM6DSV16X_XL_LOW_POWER_GY_NOT_AFFECTED = 0x1,
   LSM6DSV16X_XL_LOW_POWER_GY_SLEEP        = 0x2,
@@ -5209,8 +4872,7 @@ typedef enum
 int32_t lsm6dsv16x_act_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t val);
 int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE = 0x0,
   LSM6DSV16X_SLEEP_TO_ACT_AT_2ND_SAMPLE = 0x1,
   LSM6DSV16X_SLEEP_TO_ACT_AT_3RD_SAMPLE = 0x2,
@@ -5221,8 +4883,7 @@ int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t *val);
 
-typedef enum
-{
+typedef enum {
   LSM6DSV16X_1Hz875 = 0x0,
   LSM6DSV16X_15Hz   = 0x1,
   LSM6DSV16X_30Hz   = 0x2,
@@ -5233,8 +4894,7 @@ int32_t lsm6dsv16x_act_sleep_xl_odr_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t *val);
 
-typedef struct
-{
+typedef struct {
   lsm6dsv16x_inactivity_dur_t inactivity_cfg;
   uint8_t inactivity_ths;
   uint8_t threshold;
@@ -5245,8 +4905,7 @@ int32_t lsm6dsv16x_act_thresholds_set(stmdev_ctx_t *ctx,
 int32_t lsm6dsv16x_act_thresholds_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val);
 
-typedef struct
-{
+typedef struct {
   uint8_t shock                : 2;
   uint8_t quiet                : 4;
 } lsm6dsv16x_act_wkup_time_windows_t;

--- a/src/lsm6dsv16x_reg.h
+++ b/src/lsm6dsv16x_reg.h
@@ -75,7 +75,8 @@ extern "C" {
 #ifndef MEMS_SHARED_TYPES
 #define MEMS_SHARED_TYPES
 
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t bit0       : 1;
   uint8_t bit1       : 1;
@@ -100,6 +101,34 @@ typedef struct {
 #define PROPERTY_DISABLE                (0U)
 #define PROPERTY_ENABLE                 (1U)
 
+/** @addtogroup  Interfaces_Functions
+  * @brief       This section provide a set of functions used to read and
+  *              write a generic register of the device.
+  *              MANDATORY: return 0 -> no Error.
+  * @{
+  *
+  */
+
+typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, const uint8_t *, uint16_t);
+typedef int32_t (*stmdev_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
+typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
+
+typedef struct
+{
+  /** Component mandatory fields **/
+  stmdev_write_ptr  write_reg;
+  stmdev_read_ptr   read_reg;
+  /** Component optional fields **/
+  stmdev_mdelay_ptr   mdelay;
+  /** Customizable optional pointer **/
+  void *handle;
+} stmdev_ctx_t;
+
+/**
+  * @}
+  *
+  */
+
 #endif /* MEMS_SHARED_TYPES */
 
 #ifndef MEMS_UCF_SHARED_TYPES
@@ -116,7 +145,8 @@ typedef struct {
   *
   */
 
-typedef struct {
+typedef struct
+{
   uint8_t address;
   uint8_t data;
 } ucf_line_t;
@@ -127,33 +157,6 @@ typedef struct {
   */
 
 #endif /* MEMS_UCF_SHARED_TYPES */
-
-/**
-  * @}
-  *
-  */
-
-/** @addtogroup  LSM6DSV16X_Interfaces_Functions
-  * @brief       This section provide a set of functions used to read and
-  *              write a generic register of the device.
-  *              MANDATORY: return 0 -> no Error.
-  * @{
-  *
-  */
-
-typedef int32_t (*lsm6dsv16x_write_ptr)(void *, uint8_t,  uint8_t *, uint16_t);
-typedef int32_t (*lsm6dsv16x_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
-typedef void (*lsm6dsv16x_mdelay_ptr)(uint32_t millisec);
-
-typedef struct {
-  /** Component mandatory fields **/
-  lsm6dsv16x_write_ptr  write_reg;
-  lsm6dsv16x_read_ptr   read_reg;
-  /** Component optional fields **/
-  lsm6dsv16x_mdelay_ptr   mdelay;
-  /** Customizable optional pointer **/
-  void *handle;
-} lsm6dsv16x_ctx_t;
 
 /**
   * @}
@@ -183,7 +186,8 @@ typedef struct {
   */
 
 #define LSM6DSV16X_FUNC_CFG_ACCESS              0x1U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ois_ctrl_from_ui     : 1;
   uint8_t spi2_reset           : 1;
@@ -204,7 +208,8 @@ typedef struct {
 } lsm6dsv16x_func_cfg_access_t;
 
 #define LSM6DSV16X_PIN_CTRL                     0x2U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 5;
   uint8_t ibhr_por_en          : 1;
@@ -219,7 +224,8 @@ typedef struct {
 } lsm6dsv16x_pin_ctrl_t;
 
 #define LSM6DSV16X_IF_CFG                       0x3U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t i2c_i3c_disable      : 1;
   uint8_t not_used0            : 1;
@@ -242,7 +248,8 @@ typedef struct {
 } lsm6dsv16x_if_cfg_t;
 
 #define LSM6DSV16X_ODR_TRIG_CFG                 0x6U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t odr_trig_nodr        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -251,7 +258,8 @@ typedef struct {
 } lsm6dsv16x_odr_trig_cfg_t;
 
 #define LSM6DSV16X_FIFO_CTRL1                   0x7U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t wtm                  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -260,7 +268,8 @@ typedef struct {
 } lsm6dsv16x_fifo_ctrl1_t;
 
 #define LSM6DSV16X_FIFO_CTRL2                   0x8U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xl_dualc_batch_from_fsm       : 1;
   uint8_t uncompr_rate                  : 2;
@@ -281,7 +290,8 @@ typedef struct {
 } lsm6dsv16x_fifo_ctrl2_t;
 
 #define LSM6DSV16X_FIFO_CTRL3                  0x9U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t bdr_xl               : 4;
   uint8_t bdr_gy               : 4;
@@ -292,7 +302,8 @@ typedef struct {
 } lsm6dsv16x_fifo_ctrl3_t;
 
 #define LSM6DSV16X_FIFO_CTRL4                  0x0AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_mode            : 3;
   uint8_t g_eis_fifo_en        : 1;
@@ -307,7 +318,8 @@ typedef struct {
 } lsm6dsv16x_fifo_ctrl4_t;
 
 #define LSM6DSV16X_COUNTER_BDR_REG1            0x0BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t cnt_bdr_th           : 2;
   uint8_t not_used0            : 3;
@@ -322,7 +334,8 @@ typedef struct {
 } lsm6dsv16x_counter_bdr_reg1_t;
 
 #define LSM6DSV16X_COUNTER_BDR_REG2            0x0CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t cnt_bdr_th           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -331,7 +344,8 @@ typedef struct {
 } lsm6dsv16x_counter_bdr_reg2_t;
 
 #define LSM6DSV16X_INT1_CTRL                   0x0DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int1_drdy_xl         : 1;
   uint8_t int1_drdy_g          : 1;
@@ -354,7 +368,8 @@ typedef struct {
 } lsm6dsv16x_int1_ctrl_t;
 
 #define LSM6DSV16X_INT2_CTRL                   0x0EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_drdy_xl         : 1;
   uint8_t int2_drdy_g          : 1;
@@ -377,7 +392,8 @@ typedef struct {
 } lsm6dsv16x_int2_ctrl_t;
 
 #define LSM6DSV16X_WHO_AM_I                    0x0FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t id                   : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -386,7 +402,8 @@ typedef struct {
 } lsm6dsv16x_who_am_i_t;
 
 #define LSM6DSV16X_CTRL1                       0x10U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t odr_xl               : 4;
   uint8_t op_mode_xl           : 3;
@@ -399,7 +416,8 @@ typedef struct {
 } lsm6dsv16x_ctrl1_t;
 
 #define LSM6DSV16X_CTRL2                       0x11U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t odr_g                : 4;
   uint8_t op_mode_g            : 3;
@@ -412,7 +430,8 @@ typedef struct {
 } lsm6dsv16x_ctrl2_t;
 
 #define LSM6DSV16X_CTRL3                       0x12U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sw_reset             : 1;
   uint8_t not_used0            : 1;
@@ -431,7 +450,8 @@ typedef struct {
 } lsm6dsv16x_ctrl3_t;
 
 #define LSM6DSV16X_CTRL4                       0x13U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_in_lh           : 1;
   uint8_t drdy_pulsed          : 1;
@@ -450,7 +470,8 @@ typedef struct {
 } lsm6dsv16x_ctrl4_t;
 
 #define LSM6DSV16X_CTRL5                       0x14U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int_en_i3c           : 1;
   uint8_t bus_act_sel          : 2;
@@ -463,7 +484,8 @@ typedef struct {
 } lsm6dsv16x_ctrl5_t;
 
 #define LSM6DSV16X_CTRL6                       0x15U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_g                 : 4;
   uint8_t lpf1_g_bw            : 3;
@@ -476,7 +498,8 @@ typedef struct {
 } lsm6dsv16x_ctrl6_t;
 
 #define LSM6DSV16X_CTRL7                       0x16U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t lpf1_g_en            : 1;
   uint8_t not_used0            : 3;
@@ -493,7 +516,8 @@ typedef struct {
 } lsm6dsv16x_ctrl7_t;
 
 #define LSM6DSV16X_CTRL8                       0x17U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_xl                : 2;
   uint8_t not_used0            : 1;
@@ -510,7 +534,8 @@ typedef struct {
 } lsm6dsv16x_ctrl8_t;
 
 #define LSM6DSV16X_CTRL9                       0x18U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t usr_off_on_out       : 1;
   uint8_t usr_off_w            : 1;
@@ -533,7 +558,8 @@ typedef struct {
 } lsm6dsv16x_ctrl9_t;
 
 #define LSM6DSV16X_CTRL10                      0x19U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t st_xl                : 2;
   uint8_t st_g                 : 2;
@@ -550,7 +576,8 @@ typedef struct {
 } lsm6dsv16x_ctrl10_t;
 
 #define LSM6DSV16X_CTRL_STATUS                 0x1AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 2;
   uint8_t fsm_wr_ctrl_status   : 1;
@@ -563,7 +590,8 @@ typedef struct {
 } lsm6dsv16x_ctrl_status_t;
 
 #define LSM6DSV16X_FIFO_STATUS1                0x1BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t diff_fifo            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -572,7 +600,8 @@ typedef struct {
 } lsm6dsv16x_fifo_status1_t;
 
 #define LSM6DSV16X_FIFO_STATUS2                0x1CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t diff_fifo            : 1;
   uint8_t not_used0            : 2;
@@ -593,7 +622,8 @@ typedef struct {
 } lsm6dsv16x_fifo_status2_t;
 
 #define LSM6DSV16X_ALL_INT_SRC                 0x1DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ff_ia                : 1;
   uint8_t wu_ia                : 1;
@@ -616,7 +646,8 @@ typedef struct {
 } lsm6dsv16x_all_int_src_t;
 
 #define LSM6DSV16X_STATUS_REG                  0x1EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xlda                 : 1;
   uint8_t gda                  : 1;
@@ -639,7 +670,8 @@ typedef struct {
 } lsm6dsv16x_status_reg_t;
 
 #define LSM6DSV16X_OUT_TEMP_L                  0x20U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t temp                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -648,7 +680,8 @@ typedef struct {
 } lsm6dsv16x_out_temp_l_t;
 
 #define LSM6DSV16X_OUT_TEMP_H                  0x21U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t temp                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -657,7 +690,8 @@ typedef struct {
 } lsm6dsv16x_out_temp_h_t;
 
 #define LSM6DSV16X_OUTX_L_G                    0x22U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outx_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -666,7 +700,8 @@ typedef struct {
 } lsm6dsv16x_outx_l_g_t;
 
 #define LSM6DSV16X_OUTX_H_G                    0x23U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outx_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -675,7 +710,8 @@ typedef struct {
 } lsm6dsv16x_outx_h_g_t;
 
 #define LSM6DSV16X_OUTY_L_G                    0x24U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outy_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -684,7 +720,8 @@ typedef struct {
 } lsm6dsv16x_outy_l_g_t;
 
 #define LSM6DSV16X_OUTY_H_G                    0x25U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outy_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -693,7 +730,8 @@ typedef struct {
 } lsm6dsv16x_outy_h_g_t;
 
 #define LSM6DSV16X_OUTZ_L_G                    0x26U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outz_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -702,7 +740,8 @@ typedef struct {
 } lsm6dsv16x_outz_l_g_t;
 
 #define LSM6DSV16X_OUTZ_H_G                    0x27U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outz_g               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -711,7 +750,8 @@ typedef struct {
 } lsm6dsv16x_outz_h_g_t;
 
 #define LSM6DSV16X_OUTX_L_A                    0x28U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outx_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -720,7 +760,8 @@ typedef struct {
 } lsm6dsv16x_outx_l_a_t;
 
 #define LSM6DSV16X_OUTX_H_A                    0x29U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outx_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -729,7 +770,8 @@ typedef struct {
 } lsm6dsv16x_outx_h_a_t;
 
 #define LSM6DSV16X_OUTY_L_A                    0x2AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outy_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -738,7 +780,8 @@ typedef struct {
 } lsm6dsv16x_outy_l_a_t;
 
 #define LSM6DSV16X_OUTY_H_A                    0x2BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outy_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -747,7 +790,8 @@ typedef struct {
 } lsm6dsv16x_outy_h_a_t;
 
 #define LSM6DSV16X_OUTZ_L_A                    0x2CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outz_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -756,7 +800,8 @@ typedef struct {
 } lsm6dsv16x_outz_l_a_t;
 
 #define LSM6DSV16X_OUTZ_H_A                    0x2DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t outz_a               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -765,7 +810,8 @@ typedef struct {
 } lsm6dsv16x_outz_h_a_t;
 
 #define LSM6DSV16X_UI_OUTX_L_G_OIS_EIS         0x2EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outx_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -774,7 +820,8 @@ typedef struct {
 } lsm6dsv16x_ui_outx_l_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTX_H_G_OIS_EIS         0x2FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outx_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -783,7 +830,8 @@ typedef struct {
 } lsm6dsv16x_ui_outx_h_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTY_L_G_OIS_EIS         0x30U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outy_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -792,7 +840,8 @@ typedef struct {
 } lsm6dsv16x_ui_outy_l_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTY_H_G_OIS_EIS         0x31U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outy_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -801,7 +850,8 @@ typedef struct {
 } lsm6dsv16x_ui_outy_h_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTZ_L_G_OIS_EIS         0x32U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outz_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -810,7 +860,8 @@ typedef struct {
 } lsm6dsv16x_ui_outz_l_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTZ_H_G_OIS_EIS         0x33U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outz_g_ois_eis    : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -819,7 +870,8 @@ typedef struct {
 } lsm6dsv16x_ui_outz_h_g_ois_eis_t;
 
 #define LSM6DSV16X_UI_OUTX_L_A_OIS_DUALC       0x34U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outx_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -828,7 +880,8 @@ typedef struct {
 } lsm6dsv16x_ui_outx_l_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTX_H_A_OIS_DUALC       0x35U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outx_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -837,7 +890,8 @@ typedef struct {
 } lsm6dsv16x_ui_outx_h_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTY_L_A_OIS_DUALC       0x36U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outy_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -846,7 +900,8 @@ typedef struct {
 } lsm6dsv16x_ui_outy_l_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTY_H_A_OIS_DUALC       0x37U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outy_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -855,7 +910,8 @@ typedef struct {
 } lsm6dsv16x_ui_outy_h_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTZ_L_A_OIS_DUALC       0x38U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outz_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -864,7 +920,8 @@ typedef struct {
 } lsm6dsv16x_ui_outz_l_a_ois_dualc_t;
 
 #define LSM6DSV16X_UI_OUTZ_H_A_OIS_DUALC       0x39U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_outz_a_ois_dualc  : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -873,7 +930,8 @@ typedef struct {
 } lsm6dsv16x_ui_outz_h_a_ois_dualc_t;
 
 #define LSM6DSV16X_AH_QVAR_OUT_L               0x3AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ah_qvar              : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -882,7 +940,8 @@ typedef struct {
 } lsm6dsv16x_ah_qvar_out_l_t;
 
 #define LSM6DSV16X_AH_QVAR_OUT_H               0x3BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ah_qvar              : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -891,7 +950,8 @@ typedef struct {
 } lsm6dsv16x_ah_qvar_out_h_t;
 
 #define LSM6DSV16X_TIMESTAMP0                  0x40U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t timestamp            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -900,7 +960,8 @@ typedef struct {
 } lsm6dsv16x_timestamp0_t;
 
 #define LSM6DSV16X_TIMESTAMP1                  0x41U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t timestamp            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -909,7 +970,8 @@ typedef struct {
 } lsm6dsv16x_timestamp1_t;
 
 #define LSM6DSV16X_TIMESTAMP2                  0x42U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t timestamp            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -918,7 +980,8 @@ typedef struct {
 } lsm6dsv16x_timestamp2_t;
 
 #define LSM6DSV16X_TIMESTAMP3                  0x43U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t timestamp            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -927,7 +990,8 @@ typedef struct {
 } lsm6dsv16x_timestamp3_t;
 
 #define LSM6DSV16X_UI_STATUS_REG_OIS           0x44U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xlda_ois             : 1;
   uint8_t gda_ois              : 1;
@@ -942,7 +1006,8 @@ typedef struct {
 } lsm6dsv16x_ui_status_reg_ois_t;
 
 #define LSM6DSV16X_WAKE_UP_SRC                 0x45U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t z_wu                 : 1;
   uint8_t y_wu                 : 1;
@@ -965,7 +1030,8 @@ typedef struct {
 } lsm6dsv16x_wake_up_src_t;
 
 #define LSM6DSV16X_TAP_SRC                     0x46U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t z_tap                : 1;
   uint8_t y_tap                : 1;
@@ -988,7 +1054,8 @@ typedef struct {
 } lsm6dsv16x_tap_src_t;
 
 #define LSM6DSV16X_D6D_SRC                     0x47U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xl                   : 1;
   uint8_t xh                   : 1;
@@ -1011,7 +1078,8 @@ typedef struct {
 } lsm6dsv16x_d6d_src_t;
 
 #define LSM6DSV16X_STATUS_MASTER_MAINPAGE      0x48U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sens_hub_endop       : 1;
   uint8_t not_used0            : 2;
@@ -1032,7 +1100,8 @@ typedef struct {
 } lsm6dsv16x_status_master_mainpage_t;
 
 #define LSM6DSV16X_EMB_FUNC_STATUS_MAINPAGE    0x49U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t is_step_det          : 1;
@@ -1051,7 +1120,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_status_mainpage_t;
 
 #define LSM6DSV16X_FSM_STATUS_MAINPAGE         0x4AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t is_fsm1              : 1;
   uint8_t is_fsm2              : 1;
@@ -1074,7 +1144,8 @@ typedef struct {
 } lsm6dsv16x_fsm_status_mainpage_t;
 
 #define LSM6DSV16X_MLC_STATUS_MAINPAGE         0x4BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t is_mlc1              : 1;
   uint8_t is_mlc2              : 1;
@@ -1091,7 +1162,8 @@ typedef struct {
 } lsm6dsv16x_mlc_status_mainpage_t;
 
 #define LSM6DSV16X_INTERNAL_FREQ               0x4FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t freq_fine            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1100,7 +1172,8 @@ typedef struct {
 } lsm6dsv16x_internal_freq_t;
 
 #define LSM6DSV16X_FUNCTIONS_ENABLE            0x50U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t inact_en             : 2;
   uint8_t not_used0            : 1;
@@ -1119,7 +1192,8 @@ typedef struct {
 } lsm6dsv16x_functions_enable_t;
 
 #define LSM6DSV16X_DEN                         0x51U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t den_xl_g             : 1;
   uint8_t den_z                : 1;
@@ -1142,7 +1216,8 @@ typedef struct {
 } lsm6dsv16x_den_t;
 
 #define LSM6DSV16X_INACTIVITY_DUR              0x54U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t inact_dur            : 2;
   uint8_t xl_inact_odr         : 2;
@@ -1157,7 +1232,8 @@ typedef struct {
 } lsm6dsv16x_inactivity_dur_t;
 
 #define LSM6DSV16X_INACTIVITY_THS              0x55U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t inact_ths            : 6;
   uint8_t not_used0            : 2;
@@ -1168,7 +1244,8 @@ typedef struct {
 } lsm6dsv16x_inactivity_ths_t;
 
 #define LSM6DSV16X_TAP_CFG0                    0x56U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t lir                  : 1;
   uint8_t tap_z_en             : 1;
@@ -1191,7 +1268,8 @@ typedef struct {
 } lsm6dsv16x_tap_cfg0_t;
 
 #define LSM6DSV16X_TAP_CFG1                    0x57U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t tap_ths_x            : 5;
   uint8_t tap_priority         : 3;
@@ -1202,7 +1280,8 @@ typedef struct {
 } lsm6dsv16x_tap_cfg1_t;
 
 #define LSM6DSV16X_TAP_CFG2                    0x58U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t tap_ths_y            : 5;
   uint8_t not_used0            : 3;
@@ -1213,7 +1292,8 @@ typedef struct {
 } lsm6dsv16x_tap_cfg2_t;
 
 #define LSM6DSV16X_TAP_THS_6D                  0x59U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t tap_ths_z            : 5;
   uint8_t sixd_ths             : 2;
@@ -1226,7 +1306,8 @@ typedef struct {
 } lsm6dsv16x_tap_ths_6d_t;
 
 #define LSM6DSV16X_TAP_DUR                     0x5AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t shock                : 2;
   uint8_t quiet                : 2;
@@ -1239,7 +1320,8 @@ typedef struct {
 } lsm6dsv16x_tap_dur_t;
 
 #define LSM6DSV16X_WAKE_UP_THS                 0x5BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t wk_ths               : 6;
   uint8_t usr_off_on_wu        : 1;
@@ -1252,7 +1334,8 @@ typedef struct {
 } lsm6dsv16x_wake_up_ths_t;
 
 #define LSM6DSV16X_WAKE_UP_DUR                 0x5CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sleep_dur            : 4;
   uint8_t not_used0            : 1;
@@ -1267,7 +1350,8 @@ typedef struct {
 } lsm6dsv16x_wake_up_dur_t;
 
 #define LSM6DSV16X_FREE_FALL                   0x5DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ff_ths               : 3;
   uint8_t ff_dur               : 5;
@@ -1278,7 +1362,8 @@ typedef struct {
 } lsm6dsv16x_free_fall_t;
 
 #define LSM6DSV16X_MD1_CFG                    0x5EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int1_shub            : 1;
   uint8_t int1_emb_func        : 1;
@@ -1301,7 +1386,8 @@ typedef struct {
 } lsm6dsv16x_md1_cfg_t;
 
 #define LSM6DSV16X_MD2_CFG                    0x5FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_timestamp       : 1;
   uint8_t int2_emb_func        : 1;
@@ -1324,7 +1410,8 @@ typedef struct {
 } lsm6dsv16x_md2_cfg_t;
 
 #define LSM6DSV16X_HAODR_CFG                  0x62U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t haodr_sel            : 2;
   uint8_t not_used0            : 6;
@@ -1335,7 +1422,8 @@ typedef struct {
 } lsm6dsv16x_haodr_cfg_t;
 
 #define LSM6DSV16X_EMB_FUNC_CFG               0x63U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t emb_func_disable     : 1;
@@ -1352,7 +1440,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_cfg_t;
 
 #define LSM6DSV16X_UI_HANDSHAKE_CTRL          0x64U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_shared_req        : 1;
   uint8_t ui_shared_ack        : 1;
@@ -1365,7 +1454,8 @@ typedef struct {
 } lsm6dsv16x_ui_handshake_ctrl_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_0           0x65U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1374,7 +1464,8 @@ typedef struct {
 } lsm6dsv16x_ui_spi2_shared_0_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_1           0x66U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1383,7 +1474,8 @@ typedef struct {
 } lsm6dsv16x_ui_spi2_shared_1_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_2           0x67U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1392,7 +1484,8 @@ typedef struct {
 } lsm6dsv16x_ui_spi2_shared_2_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_3           0x68U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1401,7 +1494,8 @@ typedef struct {
 } lsm6dsv16x_ui_spi2_shared_3_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_4           0x69U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1410,7 +1504,8 @@ typedef struct {
 } lsm6dsv16x_ui_spi2_shared_4_t;
 
 #define LSM6DSV16X_UI_SPI2_SHARED_5           0x6AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ui_spi2_shared       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1419,7 +1514,8 @@ typedef struct {
 } lsm6dsv16x_ui_spi2_shared_5_t;
 
 #define LSM6DSV16X_CTRL_EIS                   0x6BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_g_eis             : 3;
   uint8_t g_eis_on_g_ois_out_reg : 1;
@@ -1436,7 +1532,8 @@ typedef struct {
 } lsm6dsv16x_ctrl_eis_t;
 
 #define LSM6DSV16X_UI_INT_OIS                 0x6FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 4;
   uint8_t st_ois_clampdis      : 1;
@@ -1453,7 +1550,8 @@ typedef struct {
 } lsm6dsv16x_ui_int_ois_t;
 
 #define LSM6DSV16X_UI_CTRL1_OIS               0x70U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_read_en         : 1;
   uint8_t ois_g_en             : 1;
@@ -1472,7 +1570,8 @@ typedef struct {
 } lsm6dsv16x_ui_ctrl1_ois_t;
 
 #define LSM6DSV16X_UI_CTRL2_OIS               0x71U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_g_ois             : 3;
   uint8_t lpf1_g_ois_bw        : 2;
@@ -1485,7 +1584,8 @@ typedef struct {
 } lsm6dsv16x_ui_ctrl2_ois_t;
 
 #define LSM6DSV16X_UI_CTRL3_OIS               0x72U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_xl_ois            : 2;
   uint8_t not_used0            : 1;
@@ -1500,7 +1600,8 @@ typedef struct {
 } lsm6dsv16x_ui_ctrl3_ois_t;
 
 #define LSM6DSV16X_X_OFS_USR                  0x73U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t x_ofs_usr            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1509,7 +1610,8 @@ typedef struct {
 } lsm6dsv16x_x_ofs_usr_t;
 
 #define LSM6DSV16X_Y_OFS_USR                  0x74U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t y_ofs_usr            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1518,7 +1620,8 @@ typedef struct {
 } lsm6dsv16x_y_ofs_usr_t;
 
 #define LSM6DSV16X_Z_OFS_USR                  0x75U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t z_ofs_usr            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1527,7 +1630,8 @@ typedef struct {
 } lsm6dsv16x_z_ofs_usr_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_TAG          0x78U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 1;
   uint8_t tag_cnt              : 2;
@@ -1540,7 +1644,8 @@ typedef struct {
 } lsm6dsv16x_fifo_data_out_tag_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_X_L          0x79U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1549,7 +1654,8 @@ typedef struct {
 } lsm6dsv16x_fifo_data_out_x_l_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_X_H          0x7AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1558,7 +1664,8 @@ typedef struct {
 } lsm6dsv16x_fifo_data_out_x_h_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_Y_L          0x7BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1567,7 +1674,8 @@ typedef struct {
 } lsm6dsv16x_fifo_data_out_y_l_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_Y_H          0x7CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1576,7 +1684,8 @@ typedef struct {
 } lsm6dsv16x_fifo_data_out_y_h_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_Z_L          0x7DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1585,7 +1694,8 @@ typedef struct {
 } lsm6dsv16x_fifo_data_out_z_l_t;
 
 #define LSM6DSV16X_FIFO_DATA_OUT_Z_H          0x7EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fifo_data_out        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1604,7 +1714,8 @@ typedef struct {
   */
 
 #define LSM6DSV16X_SPI2_WHO_AM_I              0x0FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t id                   : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1613,7 +1724,8 @@ typedef struct {
 } lsm6dsv16x_spi2_who_am_i_t;
 
 #define LSM6DSV16X_SPI2_STATUS_REG_OIS        0x1EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t xlda                 : 1;
   uint8_t gda                  : 1;
@@ -1628,7 +1740,8 @@ typedef struct {
 } lsm6dsv16x_spi2_status_reg_ois_t;
 
 #define LSM6DSV16X_SPI2_OUT_TEMP_L            0x20U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t temp                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1637,7 +1750,8 @@ typedef struct {
 } lsm6dsv16x_spi2_out_temp_l_t;
 
 #define LSM6DSV16X_SPI2_OUT_TEMP_H            0x21U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t temp                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1646,7 +1760,8 @@ typedef struct {
 } lsm6dsv16x_spi2_out_temp_h_t;
 
 #define LSM6DSV16X_SPI2_OUTX_L_G_OIS          0x22U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outx_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1655,7 +1770,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outx_l_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTX_H_G_OIS          0x23U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outx_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1664,7 +1780,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outx_h_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTY_L_G_OIS          0x24U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outy_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1673,7 +1790,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outy_l_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTY_H_G_OIS          0x25U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outy_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1682,7 +1800,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outy_h_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTZ_L_G_OIS          0x26U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outz_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1691,7 +1810,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outz_l_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTZ_H_G_OIS          0x27U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outz_g_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1700,7 +1820,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outz_h_g_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTX_L_A_OIS          0x28U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outx_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1709,7 +1830,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outx_l_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTX_H_A_OIS          0x29U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outx_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1718,7 +1840,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outx_h_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTY_L_A_OIS          0x2AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outy_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1727,7 +1850,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outy_l_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTY_H_A_OIS          0x2BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outy_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1736,7 +1860,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outy_h_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTZ_L_A_OIS          0x2CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outz_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1745,7 +1870,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outz_l_a_ois_t;
 
 #define LSM6DSV16X_SPI2_OUTZ_H_A_OIS          0x2DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_outz_a_ois      : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1754,7 +1880,8 @@ typedef struct {
 } lsm6dsv16x_spi2_outz_h_a_ois_t;
 
 #define LSM6DSV16X_SPI2_HANDSHAKE_CTRL        0x6EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_shared_ack      : 1;
   uint8_t spi2_shared_req      : 1;
@@ -1767,7 +1894,8 @@ typedef struct {
 } lsm6dsv16x_spi2_handshake_ctrl_t;
 
 #define LSM6DSV16X_SPI2_INT_OIS               0x6FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t st_xl_ois            : 2;
   uint8_t st_g_ois             : 2;
@@ -1786,7 +1914,8 @@ typedef struct {
 } lsm6dsv16x_spi2_int_ois_t;
 
 #define LSM6DSV16X_SPI2_CTRL1_OIS             0x70U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t spi2_read_en         : 1;
   uint8_t ois_g_en             : 1;
@@ -1805,7 +1934,8 @@ typedef struct {
 } lsm6dsv16x_spi2_ctrl1_ois_t;
 
 #define LSM6DSV16X_SPI2_CTRL2_OIS             0x71U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_g_ois             : 3;
   uint8_t lpf1_g_ois_bw        : 2;
@@ -1818,7 +1948,8 @@ typedef struct {
 } lsm6dsv16x_spi2_ctrl2_ois_t;
 
 #define LSM6DSV16X_SPI2_CTRL3_OIS             0x72U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fs_xl_ois            : 2;
   uint8_t not_used0            : 1;
@@ -1843,7 +1974,8 @@ typedef struct {
   */
 
 #define LSM6DSV16X_PAGE_SEL                   0x2U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 4;
   uint8_t page_sel             : 4;
@@ -1854,7 +1986,8 @@ typedef struct {
 } lsm6dsv16x_page_sel_t;
 
 #define LSM6DSV16X_EMB_FUNC_EN_A              0x4U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 1;
   uint8_t sflp_game_en         : 1;
@@ -1877,7 +2010,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_en_a_t;
 
 #define LSM6DSV16X_EMB_FUNC_EN_B              0x5U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_en               : 1;
   uint8_t not_used0            : 2;
@@ -1894,7 +2028,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_en_b_t;
 
 #define LSM6DSV16X_EMB_FUNC_EXEC_STATUS       0x7U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t emb_func_endop       : 1;
   uint8_t emb_func_exec_ovr    : 1;
@@ -1907,7 +2042,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_exec_status_t;
 
 #define LSM6DSV16X_PAGE_ADDRESS               0x8U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t page_addr            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1916,7 +2052,8 @@ typedef struct {
 } lsm6dsv16x_page_address_t;
 
 #define LSM6DSV16X_PAGE_VALUE                 0x9U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t page_value           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -1925,7 +2062,8 @@ typedef struct {
 } lsm6dsv16x_page_value_t;
 
 #define LSM6DSV16X_EMB_FUNC_INT1              0x0AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t int1_step_detector   : 1;
@@ -1944,7 +2082,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_int1_t;
 
 #define LSM6DSV16X_FSM_INT1                   0x0BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int1_fsm1            : 1;
   uint8_t int1_fsm2            : 1;
@@ -1967,7 +2106,8 @@ typedef struct {
 } lsm6dsv16x_fsm_int1_t;
 
 #define LSM6DSV16X_MLC_INT1                   0x0DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int1_mlc1            : 1;
   uint8_t int1_mlc2            : 1;
@@ -1984,7 +2124,8 @@ typedef struct {
 } lsm6dsv16x_mlc_int1_t;
 
 #define LSM6DSV16X_EMB_FUNC_INT2              0x0EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t int2_step_detector   : 1;
@@ -2003,7 +2144,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_int2_t;
 
 #define LSM6DSV16X_FSM_INT2                   0x0FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_fsm1            : 1;
   uint8_t int2_fsm2            : 1;
@@ -2026,7 +2168,8 @@ typedef struct {
 } lsm6dsv16x_fsm_int2_t;
 
 #define LSM6DSV16X_MLC_INT2                   0x11U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t int2_mlc1            : 1;
   uint8_t int2_mlc2            : 1;
@@ -2043,7 +2186,8 @@ typedef struct {
 } lsm6dsv16x_mlc_int2_t;
 
 #define LSM6DSV16X_EMB_FUNC_STATUS            0x12U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t is_step_det          : 1;
@@ -2062,7 +2206,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_status_t;
 
 #define LSM6DSV16X_FSM_STATUS                 0x13U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t is_fsm1              : 1;
   uint8_t is_fsm2              : 1;
@@ -2085,7 +2230,8 @@ typedef struct {
 } lsm6dsv16x_fsm_status_t;
 
 #define LSM6DSV16X_MLC_STATUS                 0x15U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t is_mlc1              : 1;
   uint8_t is_mlc2              : 1;
@@ -2102,7 +2248,8 @@ typedef struct {
 } lsm6dsv16x_mlc_status_t;
 
 #define LSM6DSV16X_PAGE_RW                    0x17U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 5;
   uint8_t page_read            : 1;
@@ -2117,7 +2264,8 @@ typedef struct {
 } lsm6dsv16x_page_rw_t;
 
 #define LSM6DSV16X_EMB_FUNC_FIFO_EN_A         0x44U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 1;
   uint8_t sflp_game_fifo_en    : 1;
@@ -2138,7 +2286,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_fifo_en_a_t;
 
 #define LSM6DSV16X_EMB_FUNC_FIFO_EN_B         0x45U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0                     : 1;
   uint8_t mlc_filter_feature_fifo_en    : 1;
@@ -2151,7 +2300,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_fifo_en_b_t;
 
 #define LSM6DSV16X_FSM_ENABLE                 0x46U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm1_en              : 1;
   uint8_t fsm2_en              : 1;
@@ -2174,7 +2324,8 @@ typedef struct {
 } lsm6dsv16x_fsm_enable_t;
 
 #define LSM6DSV16X_FSM_LONG_COUNTER_L         0x48U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_lc               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2183,7 +2334,8 @@ typedef struct {
 } lsm6dsv16x_fsm_long_counter_l_t;
 
 #define LSM6DSV16X_FSM_LONG_COUNTER_H         0x49U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_lc               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2192,7 +2344,8 @@ typedef struct {
 } lsm6dsv16x_fsm_long_counter_h_t;
 
 #define LSM6DSV16X_INT_ACK_MASK               0x4BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t iack_mask            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2201,7 +2354,8 @@ typedef struct {
 } lsm6dsv16x_int_ack_mask_t;
 
 #define LSM6DSV16X_FSM_OUTS1                  0x4CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm1_n_v             : 1;
   uint8_t fsm1_p_v             : 1;
@@ -2224,7 +2378,8 @@ typedef struct {
 } lsm6dsv16x_fsm_outs1_t;
 
 #define LSM6DSV16X_FSM_OUTS2                  0x4DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm2_n_v             : 1;
   uint8_t fsm2_p_v             : 1;
@@ -2247,7 +2402,8 @@ typedef struct {
 } lsm6dsv16x_fsm_outs2_t;
 
 #define LSM6DSV16X_FSM_OUTS3                  0x4EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm3_n_v             : 1;
   uint8_t fsm3_p_v             : 1;
@@ -2270,7 +2426,8 @@ typedef struct {
 } lsm6dsv16x_fsm_outs3_t;
 
 #define LSM6DSV16X_FSM_OUTS4                  0x4FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm4_n_v             : 1;
   uint8_t fsm4_p_v             : 1;
@@ -2293,7 +2450,8 @@ typedef struct {
 } lsm6dsv16x_fsm_outs4_t;
 
 #define LSM6DSV16X_FSM_OUTS5                  0x50U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm5_n_v             : 1;
   uint8_t fsm5_p_v             : 1;
@@ -2316,7 +2474,8 @@ typedef struct {
 } lsm6dsv16x_fsm_outs5_t;
 
 #define LSM6DSV16X_FSM_OUTS6                  0x51U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm6_n_v             : 1;
   uint8_t fsm6_p_v             : 1;
@@ -2339,7 +2498,8 @@ typedef struct {
 } lsm6dsv16x_fsm_outs6_t;
 
 #define LSM6DSV16X_FSM_OUTS7                  0x52U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm7_n_v             : 1;
   uint8_t fsm7_p_v             : 1;
@@ -2362,7 +2522,8 @@ typedef struct {
 } lsm6dsv16x_fsm_outs7_t;
 
 #define LSM6DSV16X_FSM_OUTS8                  0x53U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm8_n_v             : 1;
   uint8_t fsm8_p_v             : 1;
@@ -2385,7 +2546,8 @@ typedef struct {
 } lsm6dsv16x_fsm_outs8_t;
 
 #define LSM6DSV16X_SFLP_ODR                   0x5EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t sflp_game_odr        : 3;
@@ -2398,7 +2560,8 @@ typedef struct {
 } lsm6dsv16x_sflp_odr_t;
 
 #define LSM6DSV16X_FSM_ODR                    0x5FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 3;
   uint8_t fsm_odr              : 3;
@@ -2411,7 +2574,8 @@ typedef struct {
 } lsm6dsv16x_fsm_odr_t;
 
 #define LSM6DSV16X_MLC_ODR                    0x60U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 4;
   uint8_t mlc_odr              : 3;
@@ -2424,7 +2588,8 @@ typedef struct {
 } lsm6dsv16x_mlc_odr_t;
 
 #define LSM6DSV16X_STEP_COUNTER_L             0x62U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t step                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2433,7 +2598,8 @@ typedef struct {
 } lsm6dsv16x_step_counter_l_t;
 
 #define LSM6DSV16X_STEP_COUNTER_H             0x63U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t step                 : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2442,7 +2608,8 @@ typedef struct {
 } lsm6dsv16x_step_counter_h_t;
 
 #define LSM6DSV16X_EMB_FUNC_SRC               0x64U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 2;
   uint8_t stepcounter_bit_set  : 1;
@@ -2463,7 +2630,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_src_t;
 
 #define LSM6DSV16X_EMB_FUNC_INIT_A            0x66U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 1;
   uint8_t sflp_game_init       : 1;
@@ -2486,7 +2654,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_init_a_t;
 
 #define LSM6DSV16X_EMB_FUNC_INIT_B            0x67U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_init             : 1;
   uint8_t not_used0            : 2;
@@ -2503,7 +2672,8 @@ typedef struct {
 } lsm6dsv16x_emb_func_init_b_t;
 
 #define LSM6DSV16X_MLC1_SRC                   0x70U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc1_src             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2512,7 +2682,8 @@ typedef struct {
 } lsm6dsv16x_mlc1_src_t;
 
 #define LSM6DSV16X_MLC2_SRC                   0x71U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc2_src             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2521,7 +2692,8 @@ typedef struct {
 } lsm6dsv16x_mlc2_src_t;
 
 #define LSM6DSV16X_MLC3_SRC                   0x72U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc3_src             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2530,7 +2702,8 @@ typedef struct {
 } lsm6dsv16x_mlc3_src_t;
 
 #define LSM6DSV16X_MLC4_SRC                   0x73U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc4_src             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2550,7 +2723,8 @@ typedef struct {
 #define LSM6DSV16X_EMB_ADV_PG_0              0x000U
 
 #define LSM6DSV16X_SFLP_GAME_GBIASX_L        0x6EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasx               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2559,7 +2733,8 @@ typedef struct {
 } lsm6dsv16x_sflp_game_gbiasx_l_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASX_H        0x6FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasx               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2568,7 +2743,8 @@ typedef struct {
 } lsm6dsv16x_sflp_game_gbiasx_h_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASY_L        0x70U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasy               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2577,7 +2753,8 @@ typedef struct {
 } lsm6dsv16x_sflp_game_gbiasy_l_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASY_H        0x71U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasy               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2586,7 +2763,8 @@ typedef struct {
 } lsm6dsv16x_sflp_game_gbiasy_h_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASZ_L        0x72U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasz               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2595,7 +2773,8 @@ typedef struct {
 } lsm6dsv16x_sflp_game_gbiasz_l_t;
 
 #define LSM6DSV16X_SFLP_GAME_GBIASZ_H        0x73U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t gbiasz               : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2604,7 +2783,8 @@ typedef struct {
 } lsm6dsv16x_sflp_game_gbiasz_h_t;
 
 #define LSM6DSV16X_FSM_EXT_SENSITIVITY_L     0xBAU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_s            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2613,7 +2793,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_sensitivity_l_t;
 
 #define LSM6DSV16X_FSM_EXT_SENSITIVITY_H     0xBBU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_s            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2622,7 +2803,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_sensitivity_h_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFX_L            0xC0U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offx         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2631,7 +2813,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_offx_l_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFX_H            0xC1U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offx         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2640,7 +2823,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_offx_h_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFY_L            0xC2U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offy         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2649,7 +2833,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_offy_l_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFY_H            0xC3U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offy         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2658,7 +2843,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_offy_h_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFZ_L            0xC4U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offz         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2667,7 +2853,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_offz_l_t;
 
 #define LSM6DSV16X_FSM_EXT_OFFZ_H            0xC5U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_offz         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2676,7 +2863,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_offz_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XX_L       0xC6U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xx       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2685,7 +2873,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_xx_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XX_H       0xC7U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xx       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2694,7 +2883,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_xx_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XY_L       0xC8U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xy       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2703,7 +2893,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_xy_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XY_H       0xC9U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xy       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2712,7 +2903,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_xy_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XZ_L       0xCAU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2721,7 +2913,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_xz_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_XZ_H       0xCBU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_xz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2730,7 +2923,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_xz_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_YY_L       0xCCU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_yy       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2739,7 +2933,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_yy_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_YY_H       0xCDU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_yy       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2748,7 +2943,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_yy_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_YZ_L       0xCEU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_yz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2757,7 +2953,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_yz_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_YZ_H       0xCFU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_yz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2766,7 +2963,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_yz_h_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_ZZ_L       0xD0U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_zz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2775,7 +2973,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_zz_l_t;
 
 #define LSM6DSV16X_FSM_EXT_MATRIX_ZZ_H       0xD1U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_ext_mat_zz       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2784,7 +2983,8 @@ typedef struct {
 } lsm6dsv16x_fsm_ext_matrix_zz_h_t;
 
 #define LSM6DSV16X_EXT_CFG_A                 0xD4U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_z_axis           : 3;
   uint8_t not_used0            : 1;
@@ -2799,7 +2999,8 @@ typedef struct {
 } lsm6dsv16x_ext_cfg_a_t;
 
 #define LSM6DSV16X_EXT_CFG_B                 0xD5U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_x_axis           : 3;
   uint8_t not_used0            : 5;
@@ -2821,7 +3022,8 @@ typedef struct {
 #define LSM6DSV16X_EMB_ADV_PG_1             0x100U
 
 #define LSM6DSV16X_FSM_LC_TIMEOUT_L         0x7AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_lc_timeout       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2830,7 +3032,8 @@ typedef struct {
 } lsm6dsv16x_fsm_lc_timeout_l_t;
 
 #define LSM6DSV16X_FSM_LC_TIMEOUT_H         0x7BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_lc_timeout       : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2839,7 +3042,8 @@ typedef struct {
 } lsm6dsv16x_fsm_lc_timeout_h_t;
 
 #define LSM6DSV16X_FSM_PROGRAMS             0x7CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_n_prog           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2848,7 +3052,8 @@ typedef struct {
 } lsm6dsv16x_fsm_programs_t;
 
 #define LSM6DSV16X_FSM_START_ADD_L          0x7EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_start            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2857,7 +3062,8 @@ typedef struct {
 } lsm6dsv16x_fsm_start_add_l_t;
 
 #define LSM6DSV16X_FSM_START_ADD_H          0x7FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t fsm_start            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2866,7 +3072,8 @@ typedef struct {
 } lsm6dsv16x_fsm_start_add_h_t;
 
 #define LSM6DSV16X_PEDO_CMD_REG             0x83U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 2;
   uint8_t fp_rejection_en      : 1;
@@ -2881,7 +3088,8 @@ typedef struct {
 } lsm6dsv16x_pedo_cmd_reg_t;
 
 #define LSM6DSV16X_PEDO_DEB_STEPS_CONF      0x84U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t deb_step             : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2890,7 +3098,8 @@ typedef struct {
 } lsm6dsv16x_pedo_deb_steps_conf_t;
 
 #define LSM6DSV16X_PEDO_SC_DELTAT_L         0xD0U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t pd_sc                : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2899,7 +3108,8 @@ typedef struct {
 } lsm6dsv16x_pedo_sc_deltat_l_t;
 
 #define LSM6DSV16X_PEDO_SC_DELTAT_H         0xD1U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t pd_sc                : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2908,7 +3118,8 @@ typedef struct {
 } lsm6dsv16x_pedo_sc_deltat_h_t;
 
 #define LSM6DSV16X_MLC_EXT_SENSITIVITY_L    0xE8U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc_ext_s            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2917,7 +3128,8 @@ typedef struct {
 } lsm6dsv16x_mlc_ext_sensitivity_l_t;
 
 #define LSM6DSV16X_MLC_EXT_SENSITIVITY_H    0xE9U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t mlc_ext_s            : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2932,7 +3144,8 @@ typedef struct {
 #define LSM6DSV16X_EMB_ADV_PG_2             0x200U
 
 #define LSM6DSV16X_EXT_FORMAT               0x00
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t not_used0            : 2;
   uint8_t ext_format_sel       : 1;
@@ -2945,7 +3158,8 @@ typedef struct {
 } lsm6dsv16x_ext_format_t;
 
 #define LSM6DSV16X_EXT_3BYTE_SENSITIVITY_L  0x02U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_s          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2954,7 +3168,8 @@ typedef struct {
 } lsm6dsv16x_ext_3byte_sensitivity_l_t;
 
 #define LSM6DSV16X_EXT_3BYTE_SENSITIVITY_H  0x03U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_s          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2963,7 +3178,8 @@ typedef struct {
 } lsm6dsv16x_ext_3byte_sensitivity_h_t;
 
 #define LSM6DSV16X_EXT_3BYTE_OFFSET_XL      0x06U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_off        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2972,7 +3188,8 @@ typedef struct {
 } lsm6dsv16x_ext_3byte_offset_xl_t;
 
 #define LSM6DSV16X_EXT_3BYTE_OFFSET_L       0x07U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_off        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -2981,7 +3198,8 @@ typedef struct {
 } lsm6dsv16x_ext_3byte_offset_l_t;
 
 #define LSM6DSV16X_EXT_3BYTE_OFFSET_H       0x08U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t ext_3byte_off        : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3000,7 +3218,8 @@ typedef struct {
   */
 
 #define LSM6DSV16X_SENSOR_HUB_1             0x2U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub1           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3009,7 +3228,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_1_t;
 
 #define LSM6DSV16X_SENSOR_HUB_2             0x3U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub2           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3018,7 +3238,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_2_t;
 
 #define LSM6DSV16X_SENSOR_HUB_3             0x4U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub3           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3027,7 +3248,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_3_t;
 
 #define LSM6DSV16X_SENSOR_HUB_4             0x5U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub4           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3036,7 +3258,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_4_t;
 
 #define LSM6DSV16X_SENSOR_HUB_5             0x6U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub5           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3045,7 +3268,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_5_t;
 
 #define LSM6DSV16X_SENSOR_HUB_6             0x7U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub6           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3054,7 +3278,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_6_t;
 
 #define LSM6DSV16X_SENSOR_HUB_7             0x8U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub7           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3063,7 +3288,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_7_t;
 
 #define LSM6DSV16X_SENSOR_HUB_8             0x9U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub8           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3072,7 +3298,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_8_t;
 
 #define LSM6DSV16X_SENSOR_HUB_9             0x0AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub9           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3081,7 +3308,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_9_t;
 
 #define LSM6DSV16X_SENSOR_HUB_10            0x0BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub10          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3090,7 +3318,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_10_t;
 
 #define LSM6DSV16X_SENSOR_HUB_11            0x0CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub11          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3099,7 +3328,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_11_t;
 
 #define LSM6DSV16X_SENSOR_HUB_12            0x0DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub12          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3108,7 +3338,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_12_t;
 
 #define LSM6DSV16X_SENSOR_HUB_13            0x0EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub13          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3117,7 +3348,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_13_t;
 
 #define LSM6DSV16X_SENSOR_HUB_14            0x0FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub14          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3126,7 +3358,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_14_t;
 
 #define LSM6DSV16X_SENSOR_HUB_15            0x10U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub15          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3135,7 +3368,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_15_t;
 
 #define LSM6DSV16X_SENSOR_HUB_16            0x11U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub16          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3144,7 +3378,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_16_t;
 
 #define LSM6DSV16X_SENSOR_HUB_17            0x12U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub17          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3153,7 +3388,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_17_t;
 
 #define LSM6DSV16X_SENSOR_HUB_18            0x13U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sensorhub18          : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3162,7 +3398,8 @@ typedef struct {
 } lsm6dsv16x_sensor_hub_18_t;
 
 #define LSM6DSV16X_MASTER_CONFIG            0x14U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t aux_sens_on          : 2;
   uint8_t master_on            : 1;
@@ -3183,7 +3420,8 @@ typedef struct {
 } lsm6dsv16x_master_config_t;
 
 #define LSM6DSV16X_SLV0_ADD                 0x15U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t rw_0                 : 1;
   uint8_t slave0_add           : 7;
@@ -3194,7 +3432,8 @@ typedef struct {
 } lsm6dsv16x_slv0_add_t;
 
 #define LSM6DSV16X_SLV0_SUBADD              0x16U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave0_reg           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3203,7 +3442,8 @@ typedef struct {
 } lsm6dsv16x_slv0_subadd_t;
 
 #define LSM6DSV16X_SLV0_CONFIG              0x17U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave0_numop         : 3;
   uint8_t batch_ext_sens_0_en  : 1;
@@ -3218,7 +3458,8 @@ typedef struct {
 } lsm6dsv16x_slv0_config_t;
 
 #define LSM6DSV16X_SLV1_ADD                 0x18U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t r_1                  : 1;
   uint8_t slave1_add           : 7;
@@ -3229,7 +3470,8 @@ typedef struct {
 } lsm6dsv16x_slv1_add_t;
 
 #define LSM6DSV16X_SLV1_SUBADD              0x19U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave1_reg           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3238,7 +3480,8 @@ typedef struct {
 } lsm6dsv16x_slv1_subadd_t;
 
 #define LSM6DSV16X_SLV1_CONFIG              0x1AU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave1_numop         : 3;
   uint8_t batch_ext_sens_1_en  : 1;
@@ -3251,7 +3494,8 @@ typedef struct {
 } lsm6dsv16x_slv1_config_t;
 
 #define LSM6DSV16X_SLV2_ADD                 0x1BU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t r_2                  : 1;
   uint8_t slave2_add           : 7;
@@ -3262,7 +3506,8 @@ typedef struct {
 } lsm6dsv16x_slv2_add_t;
 
 #define LSM6DSV16X_SLV2_SUBADD              0x1CU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave2_reg           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3271,7 +3516,8 @@ typedef struct {
 } lsm6dsv16x_slv2_subadd_t;
 
 #define LSM6DSV16X_SLV2_CONFIG              0x1DU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave2_numop         : 3;
   uint8_t batch_ext_sens_2_en  : 1;
@@ -3284,7 +3530,8 @@ typedef struct {
 } lsm6dsv16x_slv2_config_t;
 
 #define LSM6DSV16X_SLV3_ADD                 0x1EU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t r_3                  : 1;
   uint8_t slave3_add           : 7;
@@ -3295,7 +3542,8 @@ typedef struct {
 } lsm6dsv16x_slv3_add_t;
 
 #define LSM6DSV16X_SLV3_SUBADD              0x1FU
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave3_reg           : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3304,7 +3552,8 @@ typedef struct {
 } lsm6dsv16x_slv3_subadd_t;
 
 #define LSM6DSV16X_SLV3_CONFIG              0x20U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave3_numop         : 3;
   uint8_t batch_ext_sens_3_en  : 1;
@@ -3317,7 +3566,8 @@ typedef struct {
 } lsm6dsv16x_slv3_config_t;
 
 #define LSM6DSV16X_DATAWRITE_SLV0           0x21U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t slave0_dataw         : 8;
 #elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
@@ -3326,7 +3576,8 @@ typedef struct {
 } lsm6dsv16x_datawrite_slv0_t;
 
 #define LSM6DSV16X_STATUS_MASTER            0x22U
-typedef struct {
+typedef struct
+{
 #if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
   uint8_t sens_hub_endop       : 1;
   uint8_t not_used0            : 2;
@@ -3363,7 +3614,8 @@ typedef struct {
   * @{
   *
   */
-typedef union {
+typedef union
+{
   lsm6dsv16x_func_cfg_access_t          func_cfg_access;
   lsm6dsv16x_pin_ctrl_t                 pin_ctrl;
   lsm6dsv16x_if_cfg_t                   if_cfg;
@@ -3620,10 +3872,10 @@ typedef union {
  * them with a custom implementation.
  */
 
-int32_t lsm6dsv16x_read_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
+int32_t lsm6dsv16x_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
                             uint8_t *data,
                             uint16_t len);
-int32_t lsm6dsv16x_write_reg(lsm6dsv16x_ctx_t *ctx, uint8_t reg,
+int32_t lsm6dsv16x_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
                              uint8_t *data,
                              uint16_t len);
 
@@ -3644,39 +3896,45 @@ float_t lsm6dsv16x_from_lsb_to_celsius(int16_t lsb);
 
 float_t lsm6dsv16x_from_lsb_to_nsec(uint32_t lsb);
 
-int32_t lsm6dsv16x_xl_offset_on_out_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_xl_offset_on_out_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+float_t lsm6dsv16x_from_lsb_to_mv(int16_t lsb);
 
-typedef struct {
+int32_t lsm6dsv16x_xl_offset_on_out_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_xl_offset_on_out_get(stmdev_ctx_t *ctx, uint8_t *val);
+
+typedef struct
+{
   float_t z_mg;
   float_t y_mg;
   float_t x_mg;
 } lsm6dsv16x_xl_offset_mg_t;
-int32_t lsm6dsv16x_xl_offset_mg_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_offset_mg_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t val);
-int32_t lsm6dsv16x_xl_offset_mg_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_offset_mg_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_offset_mg_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_READY             = 0x0,
   LSM6DSV16X_GLOBAL_RST        = 0x1,
   LSM6DSV16X_RESTORE_CAL_PARAM = 0x2,
   LSM6DSV16X_RESTORE_CTRL_REGS = 0x4,
 } lsm6dsv16x_reset_t;
-int32_t lsm6dsv16x_reset_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t val);
-int32_t lsm6dsv16x_reset_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_reset_t *val);
+int32_t lsm6dsv16x_reset_set(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t val);
+int32_t lsm6dsv16x_reset_get(stmdev_ctx_t *ctx, lsm6dsv16x_reset_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_MAIN_MEM_BANK       = 0x0,
   LSM6DSV16X_EMBED_FUNC_MEM_BANK = 0x1,
   LSM6DSV16X_SENSOR_HUB_MEM_BANK = 0x2,
 } lsm6dsv16x_mem_bank_t;
-int32_t lsm6dsv16x_mem_bank_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t val);
-int32_t lsm6dsv16x_mem_bank_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val);
+int32_t lsm6dsv16x_mem_bank_set(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t val);
+int32_t lsm6dsv16x_mem_bank_get(stmdev_ctx_t *ctx, lsm6dsv16x_mem_bank_t *val);
 
-int32_t lsm6dsv16x_device_id_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_device_id_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_ODR_OFF              = 0x0,
   LSM6DSV16X_ODR_AT_1Hz875        = 0x1,
   LSM6DSV16X_ODR_AT_7Hz5          = 0x2,
@@ -3711,17 +3969,18 @@ typedef enum {
   LSM6DSV16X_ODR_HA02_AT_3200Hz   = 0x2B,
   LSM6DSV16X_ODR_HA02_AT_6400Hz   = 0x2C,
 } lsm6dsv16x_data_rate_t;
-int32_t lsm6dsv16x_xl_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_data_rate_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t val);
-int32_t lsm6dsv16x_xl_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val);
-int32_t lsm6dsv16x_gy_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_data_rate_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t val);
-int32_t lsm6dsv16x_gy_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_data_rate_t *val);
 
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_XL_HIGH_PERFORMANCE_MD   = 0x0,
   LSM6DSV16X_XL_HIGH_ACCURACY_ODR_MD = 0x1,
   LSM6DSV16X_XL_ODR_TRIGGERED_MD      = 0x3,
@@ -3730,104 +3989,113 @@ typedef enum {
   LSM6DSV16X_XL_LOW_POWER_8_AVG_MD    = 0x6,
   LSM6DSV16X_XL_NORMAL_MD             = 0x7,
 } lsm6dsv16x_xl_mode_t;
-int32_t lsm6dsv16x_xl_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t val);
-int32_t lsm6dsv16x_xl_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val);
+int32_t lsm6dsv16x_xl_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t val);
+int32_t lsm6dsv16x_xl_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_xl_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_GY_HIGH_PERFORMANCE_MD   = 0x0,
   LSM6DSV16X_GY_HIGH_ACCURACY_ODR_MD = 0x1,
   LSM6DSV16X_GY_SLEEP_MD              = 0x4,
   LSM6DSV16X_GY_LOW_POWER_MD          = 0x5,
 } lsm6dsv16x_gy_mode_t;
-int32_t lsm6dsv16x_gy_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t val);
-int32_t lsm6dsv16x_gy_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val);
+int32_t lsm6dsv16x_gy_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t val);
+int32_t lsm6dsv16x_gy_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_gy_mode_t *val);
 
-int32_t lsm6dsv16x_auto_increment_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_auto_increment_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_auto_increment_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_auto_increment_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_block_data_update_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_block_data_update_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_block_data_update_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_block_data_update_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_odr_trig_cfg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_odr_trig_cfg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_odr_trig_cfg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_odr_trig_cfg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_DRDY_LATCHED = 0x0,
   LSM6DSV16X_DRDY_PULSED  = 0x1,
 } lsm6dsv16x_data_ready_mode_t;
-int32_t lsm6dsv16x_data_ready_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_data_ready_mode_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t val);
-int32_t lsm6dsv16x_data_ready_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_data_ready_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_mode_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t enable               : 1; /* interrupt enable */
   uint8_t lir                  : 1; /* interrupt pulsed or latched */
 } lsm6dsv16x_interrupt_mode_t;
-int32_t lsm6dsv16x_interrupt_enable_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_interrupt_enable_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t val);
-int32_t lsm6dsv16x_interrupt_enable_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_interrupt_enable_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_interrupt_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_125dps  = 0x0,
   LSM6DSV16X_250dps  = 0x1,
   LSM6DSV16X_500dps  = 0x2,
   LSM6DSV16X_1000dps = 0x3,
   LSM6DSV16X_2000dps = 0x4,
-  LSM6DSV16X_4000dps = 0x5,
+  LSM6DSV16X_4000dps = 0xc,
 } lsm6dsv16x_gy_full_scale_t;
-int32_t lsm6dsv16x_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_full_scale_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t val);
-int32_t lsm6dsv16x_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_full_scale_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_gy_full_scale_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_2g  = 0x0,
   LSM6DSV16X_4g  = 0x1,
   LSM6DSV16X_8g  = 0x2,
   LSM6DSV16X_16g = 0x3,
 } lsm6dsv16x_xl_full_scale_t;
-int32_t lsm6dsv16x_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_full_scale_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_xl_full_scale_t val);
-int32_t lsm6dsv16x_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_full_scale_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_xl_full_scale_t *val);
 
-int32_t lsm6dsv16x_xl_dual_channel_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_xl_dual_channel_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_xl_dual_channel_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_xl_dual_channel_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_XL_ST_DISABLE  = 0x0,
   LSM6DSV16X_XL_ST_POSITIVE = 0x1,
   LSM6DSV16X_XL_ST_NEGATIVE = 0x2,
 } lsm6dsv16x_xl_self_test_t;
-int32_t lsm6dsv16x_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_self_test_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t val);
-int32_t lsm6dsv16x_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_xl_self_test_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_xl_self_test_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_OIS_XL_ST_DISABLE  = 0x0,
   LSM6DSV16X_OIS_XL_ST_POSITIVE = 0x1,
   LSM6DSV16X_OIS_XL_ST_NEGATIVE = 0x2,
 } lsm6dsv16x_ois_xl_self_test_t;
-int32_t lsm6dsv16x_ois_xl_self_test_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_self_test_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t val);
-int32_t lsm6dsv16x_ois_xl_self_test_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_self_test_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_xl_self_test_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_GY_ST_DISABLE  = 0x0,
   LSM6DSV16X_GY_ST_POSITIVE = 0x1,
   LSM6DSV16X_GY_ST_NEGATIVE = 0x2,
 
 } lsm6dsv16x_gy_self_test_t;
-int32_t lsm6dsv16x_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_self_test_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t val);
-int32_t lsm6dsv16x_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_self_test_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_gy_self_test_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_OIS_GY_ST_DISABLE   = 0x0,
   LSM6DSV16X_OIS_GY_ST_POSITIVE  = 0x1,
   LSM6DSV16X_OIS_GY_ST_NEGATIVE  = 0x2,
@@ -3835,12 +4103,13 @@ typedef enum {
   LSM6DSV16X_OIS_GY_ST_CLAMP_NEG = 0x6,
 
 } lsm6dsv16x_ois_gy_self_test_t;
-int32_t lsm6dsv16x_ois_gy_self_test_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_self_test_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t val);
-int32_t lsm6dsv16x_ois_gy_self_test_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_self_test_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_ois_gy_self_test_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t drdy_xl              : 1;
   uint8_t drdy_gy              : 1;
   uint8_t drdy_temp            : 1;
@@ -3901,10 +4170,11 @@ typedef struct {
   uint8_t fifo_ovr             : 1;
   uint8_t fifo_th              : 1;
 } lsm6dsv16x_all_sources_t;
-int32_t lsm6dsv16x_all_sources_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_all_sources_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_all_sources_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t drdy_xl              : 1;
   uint8_t drdy_g               : 1;
   uint8_t drdy_g_eis           : 1;
@@ -3923,134 +4193,142 @@ typedef struct {
   uint8_t freefall             : 1;
   uint8_t sleep_change         : 1;
 } lsm6dsv16x_pin_int_route_t;
-int32_t lsm6dsv16x_pin_int1_route_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int1_route_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
-int32_t lsm6dsv16x_pin_int1_route_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int1_route_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
-int32_t lsm6dsv16x_pin_int2_route_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int2_route_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
-int32_t lsm6dsv16x_pin_int2_route_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_pin_int2_route_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_pin_int_route_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t drdy_xl              : 1;
   uint8_t drdy_gy              : 1;
   uint8_t drdy_temp            : 1;
 } lsm6dsv16x_data_ready_t;
-int32_t lsm6dsv16x_flag_data_ready_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_flag_data_ready_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_data_ready_t *val);
 
-int32_t lsm6dsv16x_int_ack_mask_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_int_ack_mask_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_int_ack_mask_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_int_ack_mask_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_temperature_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_temperature_raw_get(stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_ois_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_ois_angular_rate_raw_get(stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_eis_angular_rate_raw_get(stmdev_ctx_t *ctx,
                                                 int16_t *val);
 
-int32_t lsm6dsv16x_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_dual_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_dual_acceleration_raw_get(stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_ois_dual_acceleration_raw_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_dual_acceleration_raw_get(stmdev_ctx_t *ctx,
                                                  int16_t *val);
 
-int32_t lsm6dsv16x_ah_qvar_raw_get(lsm6dsv16x_ctx_t *ctx, int16_t *val);
+int32_t lsm6dsv16x_ah_qvar_raw_get(stmdev_ctx_t *ctx, int16_t *val);
 
-int32_t lsm6dsv16x_odr_cal_reg_get(lsm6dsv16x_ctx_t *ctx, int8_t *val);
+int32_t lsm6dsv16x_odr_cal_reg_get(stmdev_ctx_t *ctx, int8_t *val);
 
-int32_t lsm6dsv16x_ln_pg_write(lsm6dsv16x_ctx_t *ctx, uint16_t address,
+int32_t lsm6dsv16x_ln_pg_write(stmdev_ctx_t *ctx, uint16_t address,
                                uint8_t *buf, uint8_t len);
-int32_t lsm6dsv16x_ln_pg_read(lsm6dsv16x_ctx_t *ctx, uint16_t address, uint8_t *buf,
+int32_t lsm6dsv16x_ln_pg_read(stmdev_ctx_t *ctx, uint16_t address, uint8_t *buf,
                               uint8_t len);
 
-int32_t lsm6dsv16x_emb_function_dbg_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_emb_function_dbg_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_emb_function_dbg_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_emb_function_dbg_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_DEN_ACT_LOW  = 0x0,
   LSM6DSV16X_DEN_ACT_HIGH = 0x1,
 } lsm6dsv16x_den_polarity_t;
-int32_t lsm6dsv16x_den_polarity_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_den_polarity_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t val);
-int32_t lsm6dsv16x_den_polarity_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_den_polarity_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_den_polarity_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t stamp_in_gy_data     : 1;
   uint8_t stamp_in_xl_data     : 1;
   uint8_t den_x                : 1;
   uint8_t den_y                : 1;
   uint8_t den_z                : 1;
-  enum {
+  enum
+  {
     DEN_NOT_DEFINED = 0x00,
     LEVEL_TRIGGER   = 0x02,
     LEVEL_LATCHED   = 0x03,
   } mode;
 } lsm6dsv16x_den_conf_t;
-int32_t lsm6dsv16x_den_conf_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t val);
-int32_t lsm6dsv16x_den_conf_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_den_conf_t *val);
+int32_t lsm6dsv16x_den_conf_set(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t val);
+int32_t lsm6dsv16x_den_conf_get(stmdev_ctx_t *ctx, lsm6dsv16x_den_conf_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_EIS_125dps  = 0x0,
   LSM6DSV16X_EIS_250dps  = 0x1,
   LSM6DSV16X_EIS_500dps  = 0x2,
   LSM6DSV16X_EIS_1000dps = 0x3,
   LSM6DSV16X_EIS_2000dps = 0x4,
 } lsm6dsv16x_eis_gy_full_scale_t;
-int32_t lsm6dsv16x_eis_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_eis_gy_full_scale_set(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_eis_gy_full_scale_t val);
-int32_t lsm6dsv16x_eis_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_eis_gy_full_scale_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_eis_gy_full_scale_t *val);
 
-int32_t lsm6dsv16x_eis_gy_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_eis_gy_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_eis_gy_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_eis_gy_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_EIS_ODR_OFF = 0x0,
   LSM6DSV16X_EIS_1920Hz  = 0x1,
   LSM6DSV16X_EIS_960Hz   = 0x2,
 } lsm6dsv16x_gy_eis_data_rate_t;
-int32_t lsm6dsv16x_gy_eis_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_eis_data_rate_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_gy_eis_data_rate_t val);
-int32_t lsm6dsv16x_gy_eis_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_gy_eis_data_rate_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_gy_eis_data_rate_t *val);
 
-int32_t lsm6dsv16x_fifo_watermark_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_watermark_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_watermark_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_watermark_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_xl_dual_fsm_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_CMP_DISABLE = 0x0,
   LSM6DSV16X_CMP_8_TO_1  = 0x1,
   LSM6DSV16X_CMP_16_TO_1 = 0x2,
   LSM6DSV16X_CMP_32_TO_1 = 0x3,
 } lsm6dsv16x_fifo_compress_algo_t;
-int32_t lsm6dsv16x_fifo_compress_algo_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_set(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_fifo_compress_algo_t val);
-int32_t lsm6dsv16x_fifo_compress_algo_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_fifo_compress_algo_t *val);
 
-int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_set(stmdev_ctx_t *ctx,
                                                  uint8_t val);
-int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_virtual_sens_odr_chg_get(stmdev_ctx_t *ctx,
                                                  uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_real_time_set(stmdev_ctx_t *ctx,
                                                     uint8_t val);
-int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_compress_algo_real_time_get(stmdev_ctx_t *ctx,
                                                     uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_stop_on_wtm_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_stop_on_wtm_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_stop_on_wtm_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_stop_on_wtm_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_XL_NOT_BATCHED       = 0x0,
   LSM6DSV16X_XL_BATCHED_AT_1Hz875 = 0x1,
   LSM6DSV16X_XL_BATCHED_AT_7Hz5   = 0x2,
@@ -4065,12 +4343,13 @@ typedef enum {
   LSM6DSV16X_XL_BATCHED_AT_3840Hz = 0xb,
   LSM6DSV16X_XL_BATCHED_AT_7680Hz = 0xc,
 } lsm6dsv16x_fifo_xl_batch_t;
-int32_t lsm6dsv16x_fifo_xl_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_xl_batch_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t val);
-int32_t lsm6dsv16x_fifo_xl_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_xl_batch_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_xl_batch_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_GY_NOT_BATCHED       = 0x0,
   LSM6DSV16X_GY_BATCHED_AT_1Hz875 = 0x1,
   LSM6DSV16X_GY_BATCHED_AT_7Hz5   = 0x2,
@@ -4085,12 +4364,13 @@ typedef enum {
   LSM6DSV16X_GY_BATCHED_AT_3840Hz = 0xb,
   LSM6DSV16X_GY_BATCHED_AT_7680Hz = 0xc,
 } lsm6dsv16x_fifo_gy_batch_t;
-int32_t lsm6dsv16x_fifo_gy_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_gy_batch_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t val);
-int32_t lsm6dsv16x_fifo_gy_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_gy_batch_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fifo_gy_batch_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_BYPASS_MODE             = 0x0,
   LSM6DSV16X_FIFO_MODE               = 0x1,
   LSM6DSV16X_STREAM_WTM_TO_FULL_MODE = 0x2,
@@ -4099,51 +4379,55 @@ typedef enum {
   LSM6DSV16X_STREAM_MODE             = 0x6,
   LSM6DSV16X_BYPASS_TO_FIFO_MODE     = 0x7,
 } lsm6dsv16x_fifo_mode_t;
-int32_t lsm6dsv16x_fifo_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val);
-int32_t lsm6dsv16x_fifo_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fifo_mode_t val);
+int32_t lsm6dsv16x_fifo_mode_get(stmdev_ctx_t *ctx,
                                  lsm6dsv16x_fifo_mode_t *val);
 
-int32_t lsm6dsv16x_fifo_gy_eis_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_gy_eis_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_gy_eis_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_gy_eis_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_TEMP_NOT_BATCHED       = 0x0,
   LSM6DSV16X_TEMP_BATCHED_AT_1Hz875 = 0x1,
   LSM6DSV16X_TEMP_BATCHED_AT_15Hz   = 0x2,
   LSM6DSV16X_TEMP_BATCHED_AT_60Hz   = 0x3,
 } lsm6dsv16x_fifo_temp_batch_t;
-int32_t lsm6dsv16x_fifo_temp_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_temp_batch_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t val);
-int32_t lsm6dsv16x_fifo_temp_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_temp_batch_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_temp_batch_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_TMSTMP_NOT_BATCHED = 0x0,
   LSM6DSV16X_TMSTMP_DEC_1       = 0x1,
   LSM6DSV16X_TMSTMP_DEC_8       = 0x2,
   LSM6DSV16X_TMSTMP_DEC_32      = 0x3,
 } lsm6dsv16x_fifo_timestamp_batch_t;
-int32_t lsm6dsv16x_fifo_timestamp_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_timestamp_batch_set(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_timestamp_batch_t val);
-int32_t lsm6dsv16x_fifo_timestamp_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_timestamp_batch_get(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_timestamp_batch_t *val);
 
-int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_counter_threshold_set(stmdev_ctx_t *ctx,
                                                     uint16_t val);
-int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_counter_threshold_get(stmdev_ctx_t *ctx,
                                                     uint16_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_XL_BATCH_EVENT     = 0x0,
   LSM6DSV16X_GY_BATCH_EVENT     = 0x1,
   LSM6DSV16X_GY_EIS_BATCH_EVENT = 0x2,
 } lsm6dsv16x_fifo_batch_cnt_event_t;
-int32_t lsm6dsv16x_fifo_batch_cnt_event_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_cnt_event_set(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t val);
-int32_t lsm6dsv16x_fifo_batch_cnt_event_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_batch_cnt_event_get(stmdev_ctx_t *ctx,
                                             lsm6dsv16x_fifo_batch_cnt_event_t *val);
 
-typedef struct {
+typedef struct
+{
   uint16_t fifo_level          : 9;
   uint8_t fifo_bdr             : 1;
   uint8_t fifo_full            : 1;
@@ -4151,11 +4435,13 @@ typedef struct {
   uint8_t fifo_th              : 1;
 } lsm6dsv16x_fifo_status_t;
 
-int32_t lsm6dsv16x_fifo_status_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_status_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_fifo_status_t *val);
 
-typedef struct {
-  enum {
+typedef struct
+{
+  enum
+  {
     LSM6DSV16X_FIFO_EMPTY                    = 0x0,
     LSM6DSV16X_GY_NC_TAG                     = 0x1,
     LSM6DSV16X_XL_NC_TAG                     = 0x2,
@@ -4188,60 +4474,65 @@ typedef struct {
   uint8_t cnt;
   uint8_t data[6];
 } lsm6dsv16x_fifo_out_raw_t;
-int32_t lsm6dsv16x_fifo_out_raw_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_out_raw_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_fifo_out_raw_t *val);
 
-int32_t lsm6dsv16x_fifo_stpcnt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_stpcnt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_stpcnt_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_stpcnt_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_mlc_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_mlc_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_mlc_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_mlc_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_mlc_filt_batch_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fifo_mlc_filt_batch_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fifo_sh_batch_slave_set(lsm6dsv16x_ctx_t *ctx, uint8_t idx, uint8_t val);
-int32_t lsm6dsv16x_fifo_sh_batch_slave_get(lsm6dsv16x_ctx_t *ctx, uint8_t idx, uint8_t *val);
+int32_t lsm6dsv16x_fifo_sh_batch_slave_set(stmdev_ctx_t *ctx, uint8_t idx, uint8_t val);
+int32_t lsm6dsv16x_fifo_sh_batch_slave_get(stmdev_ctx_t *ctx, uint8_t idx, uint8_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t game_rotation        : 1;
   uint8_t gravity              : 1;
   uint8_t gbias                : 1;
 } lsm6dsv16x_fifo_sflp_raw_t;
-int32_t lsm6dsv16x_fifo_sflp_batch_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_sflp_batch_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t val);
-int32_t lsm6dsv16x_fifo_sflp_batch_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fifo_sflp_batch_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_fifo_sflp_raw_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_AUTO          = 0x0,
   LSM6DSV16X_ALWAYS_ACTIVE = 0x1,
 } lsm6dsv16x_filt_anti_spike_t;
-int32_t lsm6dsv16x_filt_anti_spike_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_anti_spike_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t val);
-int32_t lsm6dsv16x_filt_anti_spike_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_anti_spike_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_anti_spike_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t drdy                 : 1;
   uint8_t ois_drdy             : 1;
   uint8_t irq_xl               : 1;
   uint8_t irq_g                : 1;
 } lsm6dsv16x_filt_settling_mask_t;
-int32_t lsm6dsv16x_filt_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_settling_mask_set(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t val);
-int32_t lsm6dsv16x_filt_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_settling_mask_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_settling_mask_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t ois_drdy             : 1;
 } lsm6dsv16x_filt_ois_settling_mask_t;
-int32_t lsm6dsv16x_filt_ois_settling_mask_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_ois_settling_mask_set(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t val);
-int32_t lsm6dsv16x_filt_ois_settling_mask_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_ois_settling_mask_get(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_filt_ois_settling_mask_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_GY_ULTRA_LIGHT   = 0x0,
   LSM6DSV16X_GY_VERY_LIGHT    = 0x1,
   LSM6DSV16X_GY_LIGHT         = 0x2,
@@ -4251,15 +4542,16 @@ typedef enum {
   LSM6DSV16X_GY_AGGRESSIVE    = 0x6,
   LSM6DSV16X_GY_XTREME        = 0x7,
 } lsm6dsv16x_filt_gy_lp1_bandwidth_t;
-int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_filt_gy_lp1_bandwidth_t val);
-int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_lp1_bandwidth_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_filt_gy_lp1_bandwidth_t *val);
 
-int32_t lsm6dsv16x_filt_gy_lp1_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_filt_gy_lp1_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_filt_gy_lp1_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_filt_gy_lp1_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_XL_ULTRA_LIGHT = 0x0,
   LSM6DSV16X_XL_VERY_LIGHT  = 0x1,
   LSM6DSV16X_XL_LIGHT       = 0x2,
@@ -4269,72 +4561,78 @@ typedef enum {
   LSM6DSV16X_XL_AGGRESSIVE  = 0x6,
   LSM6DSV16X_XL_XTREME      = 0x7,
 } lsm6dsv16x_filt_xl_lp2_bandwidth_t;
-int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_filt_xl_lp2_bandwidth_t val);
-int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_lp2_bandwidth_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_filt_xl_lp2_bandwidth_t *val);
 
-int32_t lsm6dsv16x_filt_xl_lp2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_filt_xl_lp2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_filt_xl_lp2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_filt_xl_lp2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_filt_xl_hp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_filt_xl_hp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_filt_xl_hp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_filt_xl_hp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_filt_xl_fast_settling_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_filt_xl_fast_settling_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_filt_xl_fast_settling_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_filt_xl_fast_settling_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_HP_MD_NORMAL    = 0x0,
   LSM6DSV16X_HP_MD_REFERENCE = 0x1,
 } lsm6dsv16x_filt_xl_hp_mode_t;
-int32_t lsm6dsv16x_filt_xl_hp_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_hp_mode_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t val);
-int32_t lsm6dsv16x_filt_xl_hp_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_hp_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_filt_xl_hp_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_WK_FEED_SLOPE          = 0x0,
   LSM6DSV16X_WK_FEED_HIGH_PASS      = 0x1,
   LSM6DSV16X_WK_FEED_LP_WITH_OFFSET = 0x2,
 } lsm6dsv16x_filt_wkup_act_feed_t;
-int32_t lsm6dsv16x_filt_wkup_act_feed_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_wkup_act_feed_set(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_wkup_act_feed_t val);
-int32_t lsm6dsv16x_filt_wkup_act_feed_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_wkup_act_feed_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_filt_wkup_act_feed_t *val);
 
-int32_t lsm6dsv16x_mask_trigger_xl_settl_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_mask_trigger_xl_settl_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_mask_trigger_xl_settl_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_mask_trigger_xl_settl_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SIXD_FEED_ODR_DIV_2 = 0x0,
   LSM6DSV16X_SIXD_FEED_LOW_PASS  = 0x1,
 } lsm6dsv16x_filt_sixd_feed_t;
-int32_t lsm6dsv16x_filt_sixd_feed_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_sixd_feed_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t val);
-int32_t lsm6dsv16x_filt_sixd_feed_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_sixd_feed_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_filt_sixd_feed_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_EIS_LP_NORMAL = 0x0,
   LSM6DSV16X_EIS_LP_LIGHT  = 0x1,
 } lsm6dsv16x_filt_gy_eis_lp_bandwidth_t;
-int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t val);
-int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_eis_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_eis_lp_bandwidth_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_OIS_GY_LP_NORMAL     = 0x0,
   LSM6DSV16X_OIS_GY_LP_STRONG     = 0x1,
   LSM6DSV16X_OIS_GY_LP_AGGRESSIVE = 0x2,
   LSM6DSV16X_OIS_GY_LP_LIGHT      = 0x3,
 } lsm6dsv16x_filt_gy_ois_lp_bandwidth_t;
-int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t val);
-int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_gy_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_gy_ois_lp_bandwidth_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_OIS_XL_LP_ULTRA_LIGHT = 0x0,
   LSM6DSV16X_OIS_XL_LP_VERY_LIGHT  = 0x1,
   LSM6DSV16X_OIS_XL_LP_LIGHT       = 0x2,
@@ -4344,22 +4642,24 @@ typedef enum {
   LSM6DSV16X_OIS_XL_LP_AGGRESSIVE  = 0x6,
   LSM6DSV16X_OIS_XL_LP_XTREME      = 0x7,
 } lsm6dsv16x_filt_xl_ois_lp_bandwidth_t;
-int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_set(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t val);
-int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_filt_xl_ois_lp_bandwidth_get(stmdev_ctx_t *ctx,
                                                 lsm6dsv16x_filt_xl_ois_lp_bandwidth_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_PROTECT_CTRL_REGS = 0x0,
   LSM6DSV16X_WRITE_CTRL_REG    = 0x1,
 } lsm6dsv16x_fsm_permission_t;
-int32_t lsm6dsv16x_fsm_permission_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_permission_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t val);
-int32_t lsm6dsv16x_fsm_permission_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_permission_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_fsm_permission_t *val);
-int32_t lsm6dsv16x_fsm_permission_status(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fsm_permission_status(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t fsm1_en              : 1;
   uint8_t fsm2_en              : 1;
   uint8_t fsm3_en              : 1;
@@ -4369,14 +4669,15 @@ typedef struct {
   uint8_t fsm7_en              : 1;
   uint8_t fsm8_en              : 1;
 } lsm6dsv16x_fsm_mode_t;
-int32_t lsm6dsv16x_fsm_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val);
-int32_t lsm6dsv16x_fsm_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val);
+int32_t lsm6dsv16x_fsm_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t val);
+int32_t lsm6dsv16x_fsm_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_mode_t *val);
 
-int32_t lsm6dsv16x_fsm_long_cnt_set(lsm6dsv16x_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsv16x_fsm_long_cnt_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_fsm_long_cnt_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv16x_fsm_long_cnt_get(stmdev_ctx_t *ctx, uint16_t *val);
 
 
-typedef struct {
+typedef struct
+{
   uint8_t fsm_outs1;
   uint8_t fsm_outs2;
   uint8_t fsm_outs3;
@@ -4386,9 +4687,10 @@ typedef struct {
   uint8_t fsm_outs7;
   uint8_t fsm_outs8;
 } lsm6dsv16x_fsm_out_t;
-int32_t lsm6dsv16x_fsm_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val);
+int32_t lsm6dsv16x_fsm_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_fsm_out_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_FSM_15Hz  = 0x0,
   LSM6DSV16X_FSM_30Hz  = 0x1,
   LSM6DSV16X_FSM_60Hz  = 0x2,
@@ -4397,27 +4699,29 @@ typedef enum {
   LSM6DSV16X_FSM_480Hz = 0x5,
   LSM6DSV16X_FSM_960Hz = 0x6,
 } lsm6dsv16x_fsm_data_rate_t;
-int32_t lsm6dsv16x_fsm_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_data_rate_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fsm_data_rate_t val);
-int32_t lsm6dsv16x_fsm_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_data_rate_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_fsm_data_rate_t *val);
 
-int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_set(stmdev_ctx_t *ctx,
                                                 uint16_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
                                                 uint16_t *val);
 
-typedef struct {
+typedef struct
+{
   uint16_t z;
   uint16_t y;
   uint16_t x;
 } lsm6dsv16x_xl_fsm_ext_sens_offset_t;
-int32_t lsm6dsv16x_fsm_ext_sens_offset_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_offset_set(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_offset_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_offset_get(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_offset_t *val);
 
-typedef struct {
+typedef struct
+{
   uint16_t xx;
   uint16_t xy;
   uint16_t xz;
@@ -4425,12 +4729,13 @@ typedef struct {
   uint16_t yz;
   uint16_t zz;
 } lsm6dsv16x_xl_fsm_ext_sens_matrix_t;
-int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_matrix_set(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_matrix_get(stmdev_ctx_t *ctx,
                                            lsm6dsv16x_xl_fsm_ext_sens_matrix_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_Z_EQ_Y     = 0x0,
   LSM6DSV16X_Z_EQ_MIN_Y = 0x1,
   LSM6DSV16X_Z_EQ_X     = 0x2,
@@ -4438,12 +4743,13 @@ typedef enum {
   LSM6DSV16X_Z_EQ_MIN_Z = 0x4,
   LSM6DSV16X_Z_EQ_Z     = 0x5,
 } lsm6dsv16x_fsm_ext_sens_z_orient_t;
-int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_z_orient_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_z_orient_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_z_orient_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_Y_EQ_Y     = 0x0,
   LSM6DSV16X_Y_EQ_MIN_Y = 0x1,
   LSM6DSV16X_Y_EQ_X     = 0x2,
@@ -4451,12 +4757,13 @@ typedef enum {
   LSM6DSV16X_Y_EQ_MIN_Z = 0x4,
   LSM6DSV16X_Y_EQ_Z     = 0x5,
 } lsm6dsv16x_fsm_ext_sens_y_orient_t;
-int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_y_orient_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_y_orient_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_y_orient_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_X_EQ_Y     = 0x0,
   LSM6DSV16X_X_EQ_MIN_Y = 0x1,
   LSM6DSV16X_X_EQ_X     = 0x2,
@@ -4464,24 +4771,25 @@ typedef enum {
   LSM6DSV16X_X_EQ_MIN_Z = 0x4,
   LSM6DSV16X_X_EQ_Z     = 0x5,
 } lsm6dsv16x_fsm_ext_sens_x_orient_t;
-int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_x_orient_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_x_orient_t val);
-int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_fsm_ext_sens_x_orient_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_fsm_ext_sens_x_orient_t *val);
 
-int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(lsm6dsv16x_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_fsm_long_cnt_timeout_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv16x_fsm_long_cnt_timeout_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsv16x_fsm_number_of_programs_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_fsm_number_of_programs_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_fsm_number_of_programs_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_fsm_number_of_programs_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_fsm_start_address_set(lsm6dsv16x_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsv16x_fsm_start_address_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_fsm_start_address_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv16x_fsm_start_address_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsv16x_ff_time_windows_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ff_time_windows_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ff_time_windows_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ff_time_windows_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_156_mg = 0x0,
   LSM6DSV16X_219_mg = 0x1,
   LSM6DSV16X_250_mg = 0x2,
@@ -4491,20 +4799,22 @@ typedef enum {
   LSM6DSV16X_469_mg = 0x6,
   LSM6DSV16X_500_mg = 0x7,
 } lsm6dsv16x_ff_thresholds_t;
-int32_t lsm6dsv16x_ff_thresholds_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ff_thresholds_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t val);
-int32_t lsm6dsv16x_ff_thresholds_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ff_thresholds_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ff_thresholds_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_MLC_OFF                             = 0x0,
   LSM6DSV16X_MLC_ON                              = 0x1,
   LSM6DSV16X_MLC_ON_BEFORE_FSM                   = 0x2,
 } lsm6dsv16x_mlc_mode_t;
-int32_t lsm6dsv16x_mlc_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val);
-int32_t lsm6dsv16x_mlc_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val);
+int32_t lsm6dsv16x_mlc_set(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t val);
+int32_t lsm6dsv16x_mlc_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_MLC_15Hz  = 0x0,
   LSM6DSV16X_MLC_30Hz  = 0x1,
   LSM6DSV16X_MLC_60Hz  = 0x2,
@@ -4513,196 +4823,212 @@ typedef enum {
   LSM6DSV16X_MLC_480Hz = 0x5,
   LSM6DSV16X_MLC_960Hz = 0x6,
 } lsm6dsv16x_mlc_data_rate_t;
-int32_t lsm6dsv16x_mlc_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_data_rate_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t val);
-int32_t lsm6dsv16x_mlc_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_data_rate_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_mlc_data_rate_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t mlc1_src;
   uint8_t mlc2_src;
   uint8_t mlc3_src;
   uint8_t mlc4_src;
 } lsm6dsv16x_mlc_out_t;
-int32_t lsm6dsv16x_mlc_out_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val);
+int32_t lsm6dsv16x_mlc_out_get(stmdev_ctx_t *ctx, lsm6dsv16x_mlc_out_t *val);
 
-int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_set(stmdev_ctx_t *ctx,
                                                 uint16_t val);
-int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_mlc_ext_sens_sensitivity_get(stmdev_ctx_t *ctx,
                                                 uint16_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_OIS_CTRL_FROM_OIS = 0x0,
   LSM6DSV16X_OIS_CTRL_FROM_UI  = 0x1,
 } lsm6dsv16x_ois_ctrl_mode_t;
-int32_t lsm6dsv16x_ois_ctrl_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_ctrl_mode_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ois_ctrl_mode_t val);
-int32_t lsm6dsv16x_ois_ctrl_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_ctrl_mode_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_ois_ctrl_mode_t *val);
 
-int32_t lsm6dsv16x_ois_reset_set(lsm6dsv16x_ctx_t *ctx, int8_t val);
-int32_t lsm6dsv16x_ois_reset_get(lsm6dsv16x_ctx_t *ctx, int8_t *val);
+int32_t lsm6dsv16x_ois_reset_set(stmdev_ctx_t *ctx, int8_t val);
+int32_t lsm6dsv16x_ois_reset_get(stmdev_ctx_t *ctx, int8_t *val);
 
-int32_t lsm6dsv16x_ois_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ois_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ois_interface_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ois_interface_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t ack                  : 1;
   uint8_t req                  : 1;
 } lsm6dsv16x_ois_handshake_t;
-int32_t lsm6dsv16x_ois_handshake_from_ui_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ui_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_ois_handshake_t val);
-int32_t lsm6dsv16x_ois_handshake_from_ui_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ui_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_ois_handshake_t *val);
-int32_t lsm6dsv16x_ois_handshake_from_ois_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ois_set(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_ois_handshake_t val);
-int32_t lsm6dsv16x_ois_handshake_from_ois_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_handshake_from_ois_get(stmdev_ctx_t *ctx,
                                               lsm6dsv16x_ois_handshake_t *val);
 
-int32_t lsm6dsv16x_ois_shared_set(lsm6dsv16x_ctx_t *ctx, uint8_t val[6]);
-int32_t lsm6dsv16x_ois_shared_get(lsm6dsv16x_ctx_t *ctx, uint8_t val[6]);
+int32_t lsm6dsv16x_ois_shared_set(stmdev_ctx_t *ctx, uint8_t val[6]);
+int32_t lsm6dsv16x_ois_shared_get(stmdev_ctx_t *ctx, uint8_t val[6]);
 
-int32_t lsm6dsv16x_ois_on_spi2_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ois_on_spi2_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ois_on_spi2_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ois_on_spi2_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t gy                   : 1;
   uint8_t xl                   : 1;
 } lsm6dsv16x_ois_chain_t;
-int32_t lsm6dsv16x_ois_chain_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_ois_chain_t val);
-int32_t lsm6dsv16x_ois_chain_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_chain_set(stmdev_ctx_t *ctx, lsm6dsv16x_ois_chain_t val);
+int32_t lsm6dsv16x_ois_chain_get(stmdev_ctx_t *ctx,
                                  lsm6dsv16x_ois_chain_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_OIS_125dps  = 0x0,
   LSM6DSV16X_OIS_250dps  = 0x1,
   LSM6DSV16X_OIS_500dps  = 0x2,
   LSM6DSV16X_OIS_1000dps = 0x3,
   LSM6DSV16X_OIS_2000dps = 0x4,
 } lsm6dsv16x_ois_gy_full_scale_t;
-int32_t lsm6dsv16x_ois_gy_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_full_scale_set(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t val);
-int32_t lsm6dsv16x_ois_gy_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_gy_full_scale_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_gy_full_scale_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_OIS_2g  = 0x0,
   LSM6DSV16X_OIS_4g  = 0x1,
   LSM6DSV16X_OIS_8g  = 0x2,
   LSM6DSV16X_OIS_16g = 0x3,
 } lsm6dsv16x_ois_xl_full_scale_t;
-int32_t lsm6dsv16x_ois_xl_full_scale_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_full_scale_set(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t val);
-int32_t lsm6dsv16x_ois_xl_full_scale_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ois_xl_full_scale_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_ois_xl_full_scale_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_DEG_80 = 0x0,
   LSM6DSV16X_DEG_70 = 0x1,
   LSM6DSV16X_DEG_60 = 0x2,
   LSM6DSV16X_DEG_50 = 0x3,
 } lsm6dsv16x_6d_threshold_t;
-int32_t lsm6dsv16x_6d_threshold_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_6d_threshold_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_6d_threshold_t val);
-int32_t lsm6dsv16x_6d_threshold_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_6d_threshold_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_6d_threshold_t *val);
 
-int32_t lsm6dsv16x_4d_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_4d_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_4d_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_4d_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_2400MOhm = 0x0,
   LSM6DSV16X_730MOhm = 0x1,
   LSM6DSV16X_300MOhm = 0x2,
   LSM6DSV16X_255MOhm = 0x3,
 } lsm6dsv16x_ah_qvar_zin_t;
-int32_t lsm6dsv16x_ah_qvar_zin_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_zin_set(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t val);
-int32_t lsm6dsv16x_ah_qvar_zin_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_zin_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_ah_qvar_zin_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t ah_qvar_en           : 1;
 } lsm6dsv16x_ah_qvar_mode_t;
-int32_t lsm6dsv16x_ah_qvar_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_mode_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t val);
-int32_t lsm6dsv16x_ah_qvar_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ah_qvar_mode_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_ah_qvar_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SW_RST_DYN_ADDRESS_RST = 0x0,
   LSM6DSV16X_I3C_GLOBAL_RST         = 0x1,
 } lsm6dsv16x_i3c_reset_mode_t;
-int32_t lsm6dsv16x_i3c_reset_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_reset_mode_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t val);
-int32_t lsm6dsv16x_i3c_reset_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_reset_mode_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_i3c_reset_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_IBI_2us  = 0x0,
   LSM6DSV16X_IBI_50us = 0x1,
   LSM6DSV16X_IBI_1ms  = 0x2,
   LSM6DSV16X_IBI_25ms = 0x3,
 } lsm6dsv16x_i3c_ibi_time_t;
-int32_t lsm6dsv16x_i3c_ibi_time_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_ibi_time_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_i3c_ibi_time_t val);
-int32_t lsm6dsv16x_i3c_ibi_time_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_i3c_ibi_time_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_i3c_ibi_time_t *val);
 
-int32_t lsm6dsv16x_sh_master_interface_pull_up_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_master_interface_pull_up_set(stmdev_ctx_t *ctx,
                                                    uint8_t val);
-int32_t lsm6dsv16x_sh_master_interface_pull_up_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_master_interface_pull_up_get(stmdev_ctx_t *ctx,
                                                    uint8_t *val);
 
-int32_t lsm6dsv16x_sh_read_data_raw_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val,
+int32_t lsm6dsv16x_sh_read_data_raw_get(stmdev_ctx_t *ctx, uint8_t *val,
                                         uint8_t len);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SLV_0       = 0x0,
   LSM6DSV16X_SLV_0_1     = 0x1,
   LSM6DSV16X_SLV_0_1_2   = 0x2,
   LSM6DSV16X_SLV_0_1_2_3 = 0x3,
 } lsm6dsv16x_sh_slave_connected_t;
-int32_t lsm6dsv16x_sh_slave_connected_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_slave_connected_set(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_sh_slave_connected_t val);
-int32_t lsm6dsv16x_sh_slave_connected_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_slave_connected_get(stmdev_ctx_t *ctx,
                                           lsm6dsv16x_sh_slave_connected_t *val);
 
-int32_t lsm6dsv16x_sh_master_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sh_master_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sh_master_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sh_master_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_sh_pass_through_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sh_pass_through_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sh_pass_through_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sh_pass_through_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SH_TRG_XL_GY_DRDY = 0x0,
   LSM6DSV16X_SH_TRIG_INT2      = 0x1,
 } lsm6dsv16x_sh_syncro_mode_t;
-int32_t lsm6dsv16x_sh_syncro_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_syncro_mode_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t val);
-int32_t lsm6dsv16x_sh_syncro_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_syncro_mode_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sh_syncro_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_EACH_SH_CYCLE    = 0x0,
   LSM6DSV16X_ONLY_FIRST_CYCLE = 0x1,
 } lsm6dsv16x_sh_write_mode_t;
-int32_t lsm6dsv16x_sh_write_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_write_mode_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_sh_write_mode_t val);
-int32_t lsm6dsv16x_sh_write_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_write_mode_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_sh_write_mode_t *val);
 
-int32_t lsm6dsv16x_sh_reset_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sh_reset_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sh_reset_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sh_reset_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t   slv0_add;
   uint8_t   slv0_subadd;
   uint8_t   slv0_data;
 } lsm6dsv16x_sh_cfg_write_t;
-int32_t lsm6dsv16x_sh_cfg_write(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_cfg_write(stmdev_ctx_t *ctx,
                                 lsm6dsv16x_sh_cfg_write_t *val);
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SH_15Hz  = 0x1,
   LSM6DSV16X_SH_30Hz  = 0x2,
   LSM6DSV16X_SH_60Hz  = 0x3,
@@ -4710,87 +5036,94 @@ typedef enum {
   LSM6DSV16X_SH_240Hz = 0x5,
   LSM6DSV16X_SH_480Hz = 0x6,
 } lsm6dsv16x_sh_data_rate_t;
-int32_t lsm6dsv16x_sh_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_data_rate_set(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t val);
-int32_t lsm6dsv16x_sh_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_data_rate_get(stmdev_ctx_t *ctx,
                                     lsm6dsv16x_sh_data_rate_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t   slv_add;
   uint8_t   slv_subadd;
   uint8_t   slv_len;
 } lsm6dsv16x_sh_cfg_read_t;
-int32_t lsm6dsv16x_sh_slv_cfg_read(lsm6dsv16x_ctx_t *ctx, uint8_t idx,
+int32_t lsm6dsv16x_sh_slv_cfg_read(stmdev_ctx_t *ctx, uint8_t idx,
                                    lsm6dsv16x_sh_cfg_read_t *val);
 
-int32_t lsm6dsv16x_sh_status_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sh_status_get(stmdev_ctx_t *ctx,
                                  lsm6dsv16x_status_master_t *val);
 
-int32_t lsm6dsv16x_ui_sdo_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ui_sdo_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ui_sdo_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ui_sdo_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_I2C_I3C_ENABLE  = 0x0,
   LSM6DSV16X_I2C_I3C_DISABLE = 0x1,
 } lsm6dsv16x_ui_i2c_i3c_mode_t;
-int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ui_i2c_i3c_mode_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t val);
-int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_ui_i2c_i3c_mode_get(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_ui_i2c_i3c_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SPI_4_WIRE = 0x0,
   LSM6DSV16X_SPI_3_WIRE = 0x1,
 } lsm6dsv16x_spi_mode_t;
-int32_t lsm6dsv16x_spi_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t val);
-int32_t lsm6dsv16x_spi_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val);
+int32_t lsm6dsv16x_spi_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t val);
+int32_t lsm6dsv16x_spi_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_spi_mode_t *val);
 
-int32_t lsm6dsv16x_ui_sda_pull_up_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_ui_sda_pull_up_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_ui_sda_pull_up_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_ui_sda_pull_up_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SPI2_4_WIRE = 0x0,
   LSM6DSV16X_SPI2_3_WIRE = 0x1,
 } lsm6dsv16x_spi2_mode_t;
-int32_t lsm6dsv16x_spi2_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val);
-int32_t lsm6dsv16x_spi2_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_spi2_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_spi2_mode_t val);
+int32_t lsm6dsv16x_spi2_mode_get(stmdev_ctx_t *ctx,
                                  lsm6dsv16x_spi2_mode_t *val);
 
-int32_t lsm6dsv16x_sigmot_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sigmot_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sigmot_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sigmot_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t step_counter_enable  : 1;
   uint8_t false_step_rej       : 1;
 } lsm6dsv16x_stpcnt_mode_t;
-int32_t lsm6dsv16x_stpcnt_mode_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_stpcnt_mode_set(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_stpcnt_mode_t val);
-int32_t lsm6dsv16x_stpcnt_mode_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_stpcnt_mode_get(stmdev_ctx_t *ctx,
                                    lsm6dsv16x_stpcnt_mode_t *val);
 
-int32_t lsm6dsv16x_stpcnt_steps_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_stpcnt_steps_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsv16x_stpcnt_rst_step_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_stpcnt_rst_step_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_stpcnt_rst_step_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_stpcnt_rst_step_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_stpcnt_debounce_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_stpcnt_debounce_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_stpcnt_debounce_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_stpcnt_debounce_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_stpcnt_period_set(lsm6dsv16x_ctx_t *ctx, uint16_t val);
-int32_t lsm6dsv16x_stpcnt_period_get(lsm6dsv16x_ctx_t *ctx, uint16_t *val);
+int32_t lsm6dsv16x_stpcnt_period_set(stmdev_ctx_t *ctx, uint16_t val);
+int32_t lsm6dsv16x_stpcnt_period_get(stmdev_ctx_t *ctx, uint16_t *val);
 
-int32_t lsm6dsv16x_sflp_game_rotation_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_sflp_game_rotation_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_sflp_game_rotation_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_sflp_game_rotation_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef struct {
+typedef struct
+{
   float_t gbias_x; /* dps */
   float_t gbias_y; /* dps */
   float_t gbias_z; /* dps */
 } lsm6dsv16x_sflp_gbias_t;
-int32_t lsm6dsv16x_sflp_game_gbias_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_game_gbias_set(stmdev_ctx_t *ctx,
                                        lsm6dsv16x_sflp_gbias_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SFLP_15Hz  = 0x0,
   LSM6DSV16X_SFLP_30Hz  = 0x1,
   LSM6DSV16X_SFLP_60Hz  = 0x2,
@@ -4798,32 +5131,35 @@ typedef enum {
   LSM6DSV16X_SFLP_240Hz = 0x4,
   LSM6DSV16X_SFLP_480Hz = 0x5,
 } lsm6dsv16x_sflp_data_rate_t;
-int32_t lsm6dsv16x_sflp_data_rate_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_data_rate_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t val);
-int32_t lsm6dsv16x_sflp_data_rate_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_sflp_data_rate_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_sflp_data_rate_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t tap_x_en             : 1;
   uint8_t tap_y_en             : 1;
   uint8_t tap_z_en             : 1;
 } lsm6dsv16x_tap_detection_t;
-int32_t lsm6dsv16x_tap_detection_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_detection_set(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t val);
-int32_t lsm6dsv16x_tap_detection_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_detection_get(stmdev_ctx_t *ctx,
                                      lsm6dsv16x_tap_detection_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t x                    : 5;
   uint8_t y                    : 5;
   uint8_t z                    : 5;
 } lsm6dsv16x_tap_thresholds_t;
-int32_t lsm6dsv16x_tap_thresholds_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_thresholds_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t val);
-int32_t lsm6dsv16x_tap_thresholds_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_thresholds_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_tap_thresholds_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_XYZ  = 0x0,
   LSM6DSV16X_YXZ  = 0x1,
   LSM6DSV16X_XZY  = 0x2,
@@ -4831,85 +5167,92 @@ typedef enum {
   LSM6DSV16X_YZX  = 0x5,
   LSM6DSV16X_ZXY  = 0x6,
 } lsm6dsv16x_tap_axis_priority_t;
-int32_t lsm6dsv16x_tap_axis_priority_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_axis_priority_set(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t val);
-int32_t lsm6dsv16x_tap_axis_priority_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_axis_priority_get(stmdev_ctx_t *ctx,
                                          lsm6dsv16x_tap_axis_priority_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t shock                : 2;
   uint8_t quiet                : 2;
   uint8_t tap_gap              : 4;
 } lsm6dsv16x_tap_time_windows_t;
-int32_t lsm6dsv16x_tap_time_windows_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_time_windows_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t val);
-int32_t lsm6dsv16x_tap_time_windows_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_tap_time_windows_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_tap_time_windows_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_ONLY_SINGLE        = 0x0,
   LSM6DSV16X_BOTH_SINGLE_DOUBLE = 0x1,
 } lsm6dsv16x_tap_mode_t;
-int32_t lsm6dsv16x_tap_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t val);
-int32_t lsm6dsv16x_tap_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val);
+int32_t lsm6dsv16x_tap_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t val);
+int32_t lsm6dsv16x_tap_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_tap_mode_t *val);
 
-int32_t lsm6dsv16x_tilt_mode_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_tilt_mode_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_tilt_mode_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_tilt_mode_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-int32_t lsm6dsv16x_timestamp_raw_get(lsm6dsv16x_ctx_t *ctx, uint32_t *val);
+int32_t lsm6dsv16x_timestamp_raw_get(stmdev_ctx_t *ctx, uint32_t *val);
 
-int32_t lsm6dsv16x_timestamp_set(lsm6dsv16x_ctx_t *ctx, uint8_t val);
-int32_t lsm6dsv16x_timestamp_get(lsm6dsv16x_ctx_t *ctx, uint8_t *val);
+int32_t lsm6dsv16x_timestamp_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t lsm6dsv16x_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_XL_AND_GY_NOT_AFFECTED       = 0x0,
   LSM6DSV16X_XL_LOW_POWER_GY_NOT_AFFECTED = 0x1,
   LSM6DSV16X_XL_LOW_POWER_GY_SLEEP        = 0x2,
   LSM6DSV16X_XL_LOW_POWER_GY_POWER_DOWN   = 0x3,
 } lsm6dsv16x_act_mode_t;
-int32_t lsm6dsv16x_act_mode_set(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t val);
-int32_t lsm6dsv16x_act_mode_get(lsm6dsv16x_ctx_t *ctx, lsm6dsv16x_act_mode_t *val);
+int32_t lsm6dsv16x_act_mode_set(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t val);
+int32_t lsm6dsv16x_act_mode_get(stmdev_ctx_t *ctx, lsm6dsv16x_act_mode_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_SLEEP_TO_ACT_AT_1ST_SAMPLE = 0x0,
   LSM6DSV16X_SLEEP_TO_ACT_AT_2ND_SAMPLE = 0x1,
   LSM6DSV16X_SLEEP_TO_ACT_AT_3RD_SAMPLE = 0x2,
   LSM6DSV16X_SLEEP_TO_ACT_AT_4th_SAMPLE = 0x3,
 } lsm6dsv16x_act_from_sleep_to_act_dur_t;
-int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_from_sleep_to_act_dur_set(stmdev_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t val);
-int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_from_sleep_to_act_dur_get(stmdev_ctx_t *ctx,
                                                  lsm6dsv16x_act_from_sleep_to_act_dur_t *val);
 
-typedef enum {
+typedef enum
+{
   LSM6DSV16X_1Hz875 = 0x0,
   LSM6DSV16X_15Hz   = 0x1,
   LSM6DSV16X_30Hz   = 0x2,
   LSM6DSV16X_60Hz   = 0x3,
 } lsm6dsv16x_act_sleep_xl_odr_t;
-int32_t lsm6dsv16x_act_sleep_xl_odr_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_sleep_xl_odr_set(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t val);
-int32_t lsm6dsv16x_act_sleep_xl_odr_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_sleep_xl_odr_get(stmdev_ctx_t *ctx,
                                         lsm6dsv16x_act_sleep_xl_odr_t *val);
 
-typedef struct {
+typedef struct
+{
   lsm6dsv16x_inactivity_dur_t inactivity_cfg;
   uint8_t inactivity_ths;
   uint8_t threshold;
   uint8_t duration;
 } lsm6dsv16x_act_thresholds_t;
-int32_t lsm6dsv16x_act_thresholds_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_thresholds_set(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val);
-int32_t lsm6dsv16x_act_thresholds_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_thresholds_get(stmdev_ctx_t *ctx,
                                       lsm6dsv16x_act_thresholds_t *val);
 
-typedef struct {
+typedef struct
+{
   uint8_t shock                : 2;
   uint8_t quiet                : 4;
 } lsm6dsv16x_act_wkup_time_windows_t;
-int32_t lsm6dsv16x_act_wkup_time_windows_set(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_wkup_time_windows_set(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_act_wkup_time_windows_t val);
-int32_t lsm6dsv16x_act_wkup_time_windows_get(lsm6dsv16x_ctx_t *ctx,
+int32_t lsm6dsv16x_act_wkup_time_windows_get(stmdev_ctx_t *ctx,
                                              lsm6dsv16x_act_wkup_time_windows_t *val);
 
 /**


### PR DESCRIPTION
**Summary**
When adding the LSM6DSV family to the slimevr firmware we needed a few features that are not present in this library.

This PR fixes/implements the following **bugs/features**

* [ ] Built in Gyro and Accel Tests
* [ ] Temperature ODR and raw
* [ ] Acceleration offset
* [ ] ability to add timestamp to fifo
* [ ] Device reset
* [ ] auto increment and block update exposed
* [ ] Base library updated to the latest
* [ ] Reduced communication amount by not reading sensitivity from imu every time you get the accel/gyro

**Validation**
A slightly modified version using most of these features works in the slimevr firmware but other than that I have not tested every added feature thoroughly.

[SlimeVR Firmware](https://github.com/wigwagwent/LSM6DSV16X/tree/main)
